### PR TITLE
Port NetConstants, ByteFormatter and DateFormatter to Dart

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -66,9 +66,9 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./DimensionLib/Model/NetConstants.cs`
 
-- [ ] Port `NetConstants.cs` to Dart
+- [x] Port `NetConstants.cs` to Dart
   - **Classes**:
-    - [ ] `class NetConstants`
+    - [x] `class NetConstants`
 
 ## File: `./DimensionLib/Model/Core.cs`
 
@@ -519,11 +519,11 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/ByteFormatter.cs`
 
-- [ ] Port `ByteFormatter.cs` to Dart
+- [x] Port `ByteFormatter.cs` to Dart
   - **Classes**:
-    - [ ] `class ByteFormatter`
+    - [x] `class ByteFormatter`
   - **Public Methods**:
-    - [ ] `formatBytes()`
+    - [x] `formatBytes()`
 
 ## File: `./Dimension/UI/LimitChangeDialog.cs`
 
@@ -533,11 +533,11 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/DateFormatter.cs`
 
-- [ ] Port `DateFormatter.cs` to Dart
+- [x] Port `DateFormatter.cs` to Dart
   - **Classes**:
-    - [ ] `class DateFormatter`
+    - [x] `class DateFormatter`
   - **Public Methods**:
-    - [ ] `formatDate()`
+    - [x] `formatDate()`
 
 ## File: `./Dimension/UI/HTMLPanel.cs`
 

--- a/lib/model/net_constants.dart
+++ b/lib/model/net_constants.dart
@@ -1,18 +1,5 @@
-/*
- * Original C# Source File: DimensionLib/Model/NetConstants.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+class NetConstants {
+  static const int controlPort = 31542;
 
-namespace Dimension.Model
-{
-    public class NetConstants
-    {
-        public const int controlPort = 31542;
-    }
+  const NetConstants._();
 }
-
-*/

--- a/lib/ui/byte_formatter.dart
+++ b/lib/ui/byte_formatter.dart
@@ -1,29 +1,28 @@
-/*
- * Original C# Source File: Dimension/UI/ByteFormatter.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+class ByteFormatter {
+  static const List<String> _suffixes = [
+    'B',
+    'KB',
+    'MB',
+    'GB',
+    'TB',
+    'PB',
+    'EB',
+    'ZB',
+    'YB',
+  ];
 
-namespace Dimension.UI
-{
-    public static class ByteFormatter
-    {
-        static string[] suffixes = new string[] { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
-        public static string formatBytes(ulong b)
-        {
-            double num = b;
-            int suffixNum = 0;
-            while (num > 1024)
-            {
-                num /= 1024.0;
-                suffixNum++;
-            }
-            return (((int)(num * 100)) / 100.0).ToString() + suffixes[suffixNum];
-            }
-        }
+  static String formatBytes(int bytes) {
+    double num = bytes.toDouble();
+    int suffixNum = 0;
+
+    while (num > 1024 && suffixNum < _suffixes.length - 1) {
+      num /= 1024;
+      suffixNum++;
+    }
+
+    final rounded = ((num * 100).truncateToDouble()) / 100;
+    return '$rounded${_suffixes[suffixNum]}';
+  }
+
+  const ByteFormatter._();
 }
-
-*/

--- a/lib/ui/date_formatter.dart
+++ b/lib/ui/date_formatter.dart
@@ -1,52 +1,58 @@
-/*
- * Original C# Source File: Dimension/UI/DateFormatter.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Dimension.UI
-{
-    public static class DateFormatter
-    {
-        public static string formatDate(DateTime d)
-        {
-            TimeSpan s = DateTime.Now.Subtract(d);
-
-            if (d.Year == DateTime.MinValue.Year)
-                return "Updating...";
-
-            if (s.TotalSeconds < 0)
-                return "";
-            if ((int)s.TotalMinutes < 1)
-                return "Just Now";
-            if ((int)s.TotalMinutes == 1)
-                return "1 Minute Ago";
-            if (s.TotalMinutes < 60)
-                return ((int)s.TotalMinutes).ToString() + " Minutes Ago";
-            if ((int)s.TotalHours== 1)
-                return "1 Hour Ago";
-            if (s.TotalHours < 24)
-                return ((int)s.TotalDays).ToString() + " Hours Ago";
-            if ((int)s.TotalDays == 1)
-                return "1 Day Ago";
-            if (s.TotalDays< 7)
-                return ((int)s.TotalDays).ToString() + " Days Ago";
-            if ((int)(s.TotalDays/7) == 1)
-                return "1 Week Ago";
-            if (s.TotalDays < 4 * 7)
-                return ((int)(s.TotalDays / 7)).ToString() + " Weeks Ago";
-            if ((int)(s.TotalDays/7) == 4)
-                return "1 Month Ago";
-            if (s.TotalDays < 365)
-                return ((int)(s.TotalDays / (4 * 7))).ToString() + " Months Ago";
-            if ((int)(s.TotalDays / 365 ) == 1)
-                return "1 Year Ago";
-            return ((int)(s.TotalDays / 365)).ToString() + " Years Ago";
-        }
+class DateFormatter {
+  static String formatDate(DateTime date) {
+    if (date.year == DateTime(1).year) {
+      return 'Updating...';
     }
-}
 
-*/
+    final age = DateTime.now().difference(date);
+
+    if (age.inSeconds < 0) {
+      return '';
+    }
+    if (age.inMinutes < 1) {
+      return 'Just Now';
+    }
+    if (age.inMinutes == 1) {
+      return '1 Minute Ago';
+    }
+    if (age.inMinutes < 60) {
+      return '${age.inMinutes} Minutes Ago';
+    }
+    if (age.inHours == 1) {
+      return '1 Hour Ago';
+    }
+    if (age.inHours < 24) {
+      return '${age.inHours} Hours Ago';
+    }
+    if (age.inDays == 1) {
+      return '1 Day Ago';
+    }
+    if (age.inDays < 7) {
+      return '${age.inDays} Days Ago';
+    }
+
+    final weeks = age.inDays ~/ 7;
+    if (weeks == 1) {
+      return '1 Week Ago';
+    }
+    if (weeks < 4) {
+      return '$weeks Weeks Ago';
+    }
+    if (weeks == 4) {
+      return '1 Month Ago';
+    }
+
+    final months = age.inDays ~/ 28;
+    if (age.inDays < 365) {
+      return '$months Months Ago';
+    }
+
+    final years = age.inDays ~/ 365;
+    if (years == 1) {
+      return '1 Year Ago';
+    }
+    return '$years Years Ago';
+  }
+
+  const DateFormatter._();
+}


### PR DESCRIPTION
### Motivation
- Provide concrete Dart implementations for small utility components that were left as C# stubs to make the ported code usable in other modules.
- Ensure consistent formatting utilities for byte sizes and relative dates used throughout the UI.
- Keep the TODO tracking accurate by marking these items completed once implemented.

### Description
- Implemented `NetConstants` as a Dart utility class exposing `controlPort` and a private constructor in `lib/model/net_constants.dart`.
- Implemented `ByteFormatter.formatBytes()` in `lib/ui/byte_formatter.dart` to scale bytes with unit suffixes and truncate to two decimals.
- Implemented `DateFormatter.formatDate()` in `lib/ui/date_formatter.dart` to return human-friendly relative time strings and an "Updating..." guard.
- Updated `TODO.md` to mark `NetConstants`, `ByteFormatter`, and `DateFormatter` entries as completed.

### Testing
- Ran `git diff --check` which reported no problems and returned successfully.
- Attempted to run `dart format` on the changed files but the `dart` CLI is not available in this environment, so formatting could not be verified automatically.
- Attempted to run `flutter --version` but the `flutter` binary is not present in this environment, so no Flutter-specific checks were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ca767ba8832faa0b3e7d79dbbb6b)