### PR TITLE
docs: add interim dart-udt guidance to TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,6 +39,7 @@ This document outlines the tasks required to port the C# application to a Dart/F
     - [ ] `connecting`
   - **TODO**:
     - [ ] Implement UDT via Dart FFI (wrapping C/C++ library) or rewrite using `RawDatagramSocket`. Currently, Dart implementations are stubs.
+    - [ ] Currently porting `dart-udt`; in the meantime, use a mock transport or mark related behavior as not implemented until the port is ready. Additional details will be added later.
 
 ## File: `./DimensionLib/Model/OutgoingConnection.cs`
 
@@ -176,6 +177,7 @@ This document outlines the tasks required to port the C# application to a Dart/F
     - [ ] `connecting`
   - **TODO**:
     - [ ] Implement UDT via Dart FFI (wrapping C/C++ library) or rewrite using `RawDatagramSocket`. Currently, Dart implementations are stubs.
+    - [ ] Currently porting `dart-udt`; in the meantime, use a mock transport or mark related behavior as not implemented until the port is ready. Additional details will be added later.
 
 ## File: `./DimensionLib/Model/Peer.cs`
 


### PR DESCRIPTION
### Motivation
- Make it explicit in the project TODO that `dart-udt` is currently being ported and that consumers should use a mock transport or mark UDT-related behavior as not implemented until the port is ready.

### Description
- Added an interim TODO note in `TODO.md` under the `./DimensionLib/Model/UdtOutgoingConnection.cs` section advising to use a mock transport or mark behavior as not implemented until `dart-udt` is available.
- Added the same interim TODO note in `TODO.md` under the `./DimensionLib/Model/UdtIncomingConnection.cs` section for consistency.

### Testing
- Documentation-only change; no unit tests were run, and the update to `TODO.md` was verified in the workspace (checked file contents and `git status --short`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2cde5eb98832fa371e7585f710aab)