### PR TITLE
Port Serializer to pure Dart with testable codec registry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -126,13 +126,16 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./DimensionLib/Model/Serializer.cs`
 
-- [ ] Port `Serializer.cs` to Dart
+- [x] Port `Serializer.cs` to Dart
   - **Classes**:
-    - [ ] `class Serializer`
+    - [x] `class Serializer`
   - **Public Methods**:
-    - [ ] `serialize()`
-    - [ ] `getType()`
-    - [ ] `getText()`
+    - [x] `serialize()`
+    - [x] `getType()`
+    - [x] `getText()`
+
+  - **TODO**:
+    - [ ] Register all concrete command codecs in app startup so runtime networking paths can deserialize every command type.
 
 ## File: `./DimensionLib/Model/LoopbackIncomingConnection.cs`
 

--- a/agents.md
+++ b/agents.md
@@ -18,3 +18,5 @@ This file contains instructions and context for agents working on this repositor
 - Default storage is in-memory (`InMemoryStringKeyValueStore`) to keep unit tests deterministic and avoid filesystem/network dependencies.
 - `getObject`/`setObject` rely on explicit JSON serializers instead of reflection, which keeps code mockable and Dart-native.
 - Temporary bridge: `FileListDatabase` includes a `settingsStore` until `Settings` is fully ported and wired.
+- `lib/model/serializer.dart` is now a pure-Dart packet serializer with an explicit codec registry (`register<T>`), so command serialization/deserialization can be tested with mocks and does not rely on reflection.
+- Temporary follow-up: command codec registration is intentionally externalized; wire all command types during app bootstrap once `App`/startup flow is fully Dart-native.

--- a/lib/model/serializer.dart
+++ b/lib/model/serializer.dart
@@ -1,88 +1,115 @@
-/*
- * Original C# Source File: DimensionLib/Model/Serializer.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+import 'dart:convert';
+import 'dart:typed_data';
 
-namespace Dimension.Model
-{
-    public class Serializer
-    {
-        Dictionary<string, Type> commandTypes = new Dictionary<string, Type>();
+import 'commands/command.dart';
 
-        public Serializer()
-        {
-            foreach (Type t in System.Reflection.Assembly.GetExecutingAssembly().GetTypes())
-                if (t.IsSubclassOf(typeof(Commands.Command)))
-                    commandTypes.Add(t.FullName, t);
-        }
-        public byte[] serialize(Commands.Command c)
-        {
-            System.IO.MemoryStream m = new System.IO.MemoryStream();
-            System.IO.BinaryWriter b = new System.IO.BinaryWriter(m);
-            string t = c.GetType().FullName;
-            b.Write(Encoding.UTF8.GetByteCount(t));
-            b.Write(Encoding.UTF8.GetBytes(t));
+typedef CommandEncoder<T extends Command> = Map<String, dynamic> Function(T command);
+typedef CommandDecoder<T extends Command> = T Function(Map<String, dynamic> json);
 
-            string d = Newtonsoft.Json.JsonConvert.SerializeObject(c);
-            b.Write(Encoding.UTF8.GetByteCount(d));
-            b.Write(Encoding.UTF8.GetBytes(d));
-            b.Flush();
-            byte[] output = m.ToArray();
-            b.Dispose();
-            m.Dispose();
+class Serializer {
+  final Map<String, _CodecEntry<Command>> _codecsByType =
+      <String, _CodecEntry<Command>>{};
+  final Map<Type, String> _typeNamesByCommandType = <Type, String>{};
 
+  void register<T extends Command>({
+    required String typeName,
+    required CommandEncoder<T> encode,
+    required CommandDecoder<T> decode,
+  }) {
+    _codecsByType[typeName] = _CodecEntry<Command>(
+      encode: (Command command) => encode(command as T),
+      decode: (Map<String, dynamic> json) => decode(json),
+    );
+    _typeNamesByCommandType[T] = typeName;
+  }
 
-            return output;
-        }
-        public string getType(byte[] b)
-        {
-            System.IO.MemoryStream m = new System.IO.MemoryStream(b);
-            System.IO.BinaryReader br = new System.IO.BinaryReader(m);
-
-            int tl = br.ReadInt32();
-            string t = Encoding.UTF8.GetString(br.ReadBytes(tl));
-            
-            return t;
-        }
-        public string getText(byte[] b)
-        {
-            System.IO.MemoryStream m = new System.IO.MemoryStream(b);
-            System.IO.BinaryReader br = new System.IO.BinaryReader(m);
-
-            int tl = br.ReadInt32();
-            string t = Encoding.UTF8.GetString(br.ReadBytes(tl));
-            int dl = br.ReadInt32();
-            string d = Encoding.UTF8.GetString(br.ReadBytes(dl));
-
-
-            return d;
-        }
-        public Commands.Command deserialize(byte[] b)
-        {
-            System.IO.MemoryStream m = new System.IO.MemoryStream(b);
-            System.IO.BinaryReader br = new System.IO.BinaryReader(m);
-
-            int tl = br.ReadInt32();
-            string t = Encoding.UTF8.GetString(br.ReadBytes(tl));
-            int dl = br.ReadInt32();
-            string d = Encoding.UTF8.GetString(br.ReadBytes(dl));
-
-            try
-            {
-                if (commandTypes.ContainsKey(t))
-                    return (Commands.Command)Newtonsoft.Json.JsonConvert.DeserializeObject(d, commandTypes[t]);
-            }
-            catch (Newtonsoft.Json.JsonSerializationException)
-            {
-                return null;    //invalid data, ignore
-            }
-            return null;
-        }
+  Uint8List serialize(Command command) {
+    final typeName = _typeNamesByCommandType[command.runtimeType];
+    if (typeName == null) {
+      throw StateError('No command codec registered for ${command.runtimeType}.');
     }
+
+    final codec = _codecsByType[typeName]!;
+    final typeBytes = utf8.encode(typeName);
+    final payloadText = jsonEncode(codec.encode(command));
+    final payloadBytes = utf8.encode(payloadText);
+
+    final output = Uint8List(8 + typeBytes.length + payloadBytes.length);
+    final byteData = ByteData.view(output.buffer);
+    byteData.setInt32(0, typeBytes.length, Endian.little);
+    output.setRange(4, 4 + typeBytes.length, typeBytes);
+    byteData.setInt32(4 + typeBytes.length, payloadBytes.length, Endian.little);
+    output.setRange(8 + typeBytes.length, output.length, payloadBytes);
+    return output;
+  }
+
+  String getType(Uint8List data) {
+    final reader = _PacketReader(data);
+    return reader.readString();
+  }
+
+  String getText(Uint8List data) {
+    final reader = _PacketReader(data);
+    reader.readString(); // command type
+    return reader.readString();
+  }
+
+  Command? deserialize(Uint8List data) {
+    try {
+      final typeName = getType(data);
+      final codec = _codecsByType[typeName];
+      if (codec == null) {
+        return null;
+      }
+
+      final jsonText = getText(data);
+      final dynamic decoded = jsonDecode(jsonText);
+      if (decoded is! Map<String, dynamic>) {
+        return null;
+      }
+      return codec.decode(decoded);
+    } on FormatException {
+      return null;
+    }
+  }
 }
 
-*/
+class _CodecEntry<T extends Command> {
+  const _CodecEntry({required this.encode, required this.decode});
+
+  final Map<String, dynamic> Function(T command) encode;
+  final T Function(Map<String, dynamic> json) decode;
+}
+
+class _PacketReader {
+  _PacketReader(this._data);
+
+  final Uint8List _data;
+  int _offset = 0;
+
+  String readString() {
+    final length = _readLength();
+    if (_offset + length > _data.length) {
+      throw const FormatException('Packet data is truncated.');
+    }
+
+    final bytes = _data.sublist(_offset, _offset + length);
+    _offset += length;
+    return utf8.decode(bytes);
+  }
+
+  int _readLength() {
+    if (_offset + 4 > _data.length) {
+      throw const FormatException('Packet data is truncated.');
+    }
+
+    final value = ByteData.sublistView(_data, _offset, _offset + 4)
+        .getInt32(0, Endian.little);
+    _offset += 4;
+
+    if (value < 0) {
+      throw const FormatException('Negative field length in packet.');
+    }
+    return value;
+  }
+}

--- a/test/serializer_test.dart
+++ b/test/serializer_test.dart
@@ -1,0 +1,81 @@
+import 'dart:typed_data';
+
+import 'package:dimension/model/commands/command.dart';
+import 'package:dimension/model/serializer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestCommand extends Command {
+  _TestCommand(this.value);
+
+  final String value;
+}
+
+void main() {
+  group('Serializer', () {
+    test('serializes type and JSON payload in little-endian packet format', () {
+      final serializer = Serializer()
+        ..register<_TestCommand>(
+          typeName: 'Dimension.Model.Commands.TestCommand',
+          encode: (command) => <String, dynamic>{'value': command.value},
+          decode: (json) => _TestCommand(json['value'] as String? ?? ''),
+        );
+
+      final packet = serializer.serialize(_TestCommand('hello'));
+
+      expect(
+        serializer.getType(packet),
+        'Dimension.Model.Commands.TestCommand',
+      );
+      expect(serializer.getText(packet), '{"value":"hello"}');
+    });
+
+    test('deserialize rebuilds command via registered decoder', () {
+      final serializer = Serializer()
+        ..register<_TestCommand>(
+          typeName: 'Dimension.Model.Commands.TestCommand',
+          encode: (command) => <String, dynamic>{'value': command.value},
+          decode: (json) => _TestCommand(json['value'] as String? ?? ''),
+        );
+
+      final command = _TestCommand('rebuilt');
+      final packet = serializer.serialize(command);
+
+      final decoded = serializer.deserialize(packet);
+      expect(decoded, isA<_TestCommand>());
+      expect((decoded as _TestCommand).value, 'rebuilt');
+    });
+
+    test('deserialize returns null for unknown command types', () {
+      final serializer = Serializer()
+        ..register<_TestCommand>(
+          typeName: 'KnownCommand',
+          encode: (command) => <String, dynamic>{'value': command.value},
+          decode: (json) => _TestCommand(json['value'] as String? ?? ''),
+        );
+
+      final bytes = _buildPacket('UnknownCommand', '{"value":"x"}');
+      expect(serializer.deserialize(bytes), isNull);
+    });
+
+    test('deserialize returns null when packet is truncated', () {
+      final serializer = Serializer();
+      final truncated = Uint8List.fromList(<int>[1, 0, 0, 0, 65]);
+
+      expect(serializer.deserialize(truncated), isNull);
+    });
+  });
+}
+
+Uint8List _buildPacket(String type, String payload) {
+  final typeBytes = type.codeUnits;
+  final payloadBytes = payload.codeUnits;
+
+  final result = Uint8List(8 + typeBytes.length + payloadBytes.length);
+  final header = ByteData.sublistView(result);
+  header.setInt32(0, typeBytes.length, Endian.little);
+  result.setRange(4, 4 + typeBytes.length, typeBytes);
+  header.setInt32(4 + typeBytes.length, payloadBytes.length, Endian.little);
+  result.setRange(8 + typeBytes.length, result.length, payloadBytes);
+
+  return result;
+}


### PR DESCRIPTION
### Motivation
- Replace the commented C# placeholder serializer with a Dart-native implementation to avoid reflection and enable testable, mockable command (de)serialization.
- Make packet framing explicit and deterministic (little-endian length-prefix + JSON payload) so networking code can reliably parse and validate messages.

### Description
- Implemented a pure-Dart `Serializer` in `lib/model/serializer.dart` with an explicit codec registry via `register<T>` and typed encoder/decoder callbacks. 
- Implemented `serialize`, `getType`, `getText`, and `deserialize` using little-endian length prefixes and JSON payloads, plus `_PacketReader` and `_CodecEntry` helpers for robust parsing. 
- Added focused unit tests at `test/serializer_test.dart` that verify packet layout, round-trip decode, unknown-type handling, and truncated-packet safety. 
- Updated `TODO.md` to mark the serializer as ported and added a follow-up TODO to register all concrete command codecs at app startup, and updated `agents.md` to document the new serializer approach.

### Testing
- Added unit tests in `test/serializer_test.dart` that exercise the `Serializer` API and packet parsing behavior (ready for CI or local execution).
- Attempted to run analysis and runtime tests in this environment but `dart`/`flutter` are not installed here, so `dart analyze` and `flutter test` were not executed and therefore no automated test run completed in-container.
- The tests are written to be deterministic and avoid filesystem/network dependencies and should pass when run in a CI or local environment with the Dart/Flutter SDK installed using `flutter test test/serializer_test.dart` and checked with `dart analyze`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2cdb997dc832f8d6de555d48502f1)