### PR TITLE
Port Settings model to pure Dart with injectable storage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -221,20 +221,21 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./DimensionLib/Model/Settings.cs`
 
-- [ ] Port `Settings.cs` to Dart
+- [x] Port `Settings.cs` to Dart
   - **TODO**:
     - [ ] Replace `FileListDatabase.settingsStore` temporary bridge with the concrete Dart `Settings` implementation once available.
+    - [ ] Optional persistence hook currently relies on `SavableStringKeyValueStore`; wire a real disk-backed settings store during app bootstrap.
   - **Classes**:
-    - [ ] `class Settings`
+    - [x] `class Settings`
   - **Public Methods**:
-    - [ ] `save()`
-    - [ ] `getStringArray()`
-    - [ ] `addStringToArrayNoDup()`
-    - [ ] `removeStringToArrayNoDup()`
-    - [ ] `setStringArray()`
+    - [x] `save()`
+    - [x] `getStringArray()`
+    - [x] `addStringToArrayNoDup()`
+    - [x] `removeStringToArrayNoDup()`
+    - [x] `setStringArray()`
     - [x] `getULong()`
-    - [ ] `setBool()`
-    - [ ] `getBool()`
+    - [x] `setBool()`
+    - [x] `getBool()`
     - [x] `setString()`
     - [x] `getString()`
     - [x] `setULong()`

--- a/agents.md
+++ b/agents.md
@@ -20,3 +20,5 @@ This file contains instructions and context for agents working on this repositor
 - Temporary bridge: `FileListDatabase` includes a `settingsStore` until `Settings` is fully ported and wired.
 - `lib/model/serializer.dart` is now a pure-Dart packet serializer with an explicit codec registry (`register<T>`), so command serialization/deserialization can be tested with mocks and does not rely on reflection.
 - Temporary follow-up: command codec registration is intentionally externalized; wire all command types during app bootstrap once `App`/startup flow is fully Dart-native.
+- `lib/model/settings.dart` is now a pure-Dart implementation with an injected `StringKeyValueStore`, deterministic in-memory defaults, and explicit JSON handling for string-array settings.
+- Temporary follow-up: `Settings.save()` only persists when the injected backend implements `SavableStringKeyValueStore`; wire a disk-backed implementation during app bootstrap.

--- a/test/settings_test.dart
+++ b/test/settings_test.dart
@@ -1,0 +1,58 @@
+import 'package:dimension/model/file_list_database.dart';
+import 'package:dimension/model/settings.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class FakeSavableStore extends InMemoryStringKeyValueStore
+    implements SavableStringKeyValueStore {
+  int saveCallCount = 0;
+
+  @override
+  void save() {
+    saveCallCount += 1;
+  }
+}
+
+void main() {
+  group('Settings', () {
+    test('reads and writes primitive values', () {
+      final settings = Settings();
+
+      expect(settings.getString('missing', 'fallback'), 'fallback');
+      expect(settings.getInt('missing-int', 42), 42);
+      expect(settings.getULong('missing-ulong', 7), 7);
+      expect(settings.getBool('missing-bool', true), isTrue);
+
+      settings.setString('username', 'alice');
+      settings.setInt('max peers', 88);
+      settings.setULong('quota', 1024);
+      settings.setBool('enabled', false);
+
+      expect(settings.getString('username', 'fallback'), 'alice');
+      expect(settings.getInt('max peers', 0), 88);
+      expect(settings.getULong('quota', 0), 1024);
+      expect(settings.getBool('enabled', true), isFalse);
+    });
+
+    test('deduplicates and removes string-array values', () {
+      final settings = Settings();
+
+      settings.addStringToArrayNoDup('circles', 'alpha');
+      settings.addStringToArrayNoDup('circles', 'alpha');
+      settings.addStringToArrayNoDup('circles', 'beta');
+
+      expect(settings.getStringArray('circles'), <String>['alpha', 'beta']);
+
+      settings.removeStringToArrayNoDup('circles', 'alpha');
+      expect(settings.getStringArray('circles'), <String>['beta']);
+    });
+
+    test('save delegates to backend when supported', () {
+      final store = FakeSavableStore();
+      final settings = Settings(store: store);
+
+      settings.save();
+
+      expect(store.saveCallCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
### Motivation
- Replace the commented C# `Settings` placeholder with an idiomatic, testable Dart implementation to unblock other ports that depend on settings storage.
- Remove hard filesystem dependencies in tests by using an injectable key-value backend and deterministic in-memory defaults.
- Provide a clear injection point for future durable persistence without forcing a production dependency now.

### Description
- Add `lib/model/settings.dart` implementing `class Settings` and an optional `SavableStringKeyValueStore` interface for backends that support explicit persistence, using an injected `StringKeyValueStore` (default `InMemoryStringKeyValueStore`).
- Implement full method parity for the tracked helpers: `getStringArray`, `addStringToArrayNoDup`, `removeStringToArrayNoDup`, `setStringArray`, `getULong`, `setBool`, `getBool`, `setString`, `getString`, `setULong`, `setInt`, `getInt`, and `save` (delegates to backend when supported).
- Add unit tests in `test/settings_test.dart` covering primitive reads/writes, string-array dedup/remove semantics, and persistence delegation via a fake `SavableStringKeyValueStore`.
- Update `TODO.md` and `agents.md` to mark the `Settings` port completed and add follow-up notes to wire a disk-backed `SavableStringKeyValueStore` during app bootstrap and replace the temporary `settingsStore` bridge in `FileListDatabase`.

### Testing
- Added unit tests (`test/settings_test.dart`) that exercise read/write behavior, string-array dedupe/removal, and `save()` delegation; these tests were added but could not be executed in this environment because the `flutter`/`dart` tooling is not available here (test run failed with `flutter`/`dart` not found).
- Ran repository whitespace/diff checks (`git diff --check`) which reported no issues.
- Note: `flutter test` / `flutter analyze` were attempted but failed in this environment due to missing `flutter` binary; the tests pass locally/CI where Flutter/Dart are available is expected given the in-memory-only defaults used in the implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2cfe483ec832f9def8fafba5a9dac)