### PR TITLE
Introduce testable UDT transport bridge and make GlobalSpeedLimiter testable

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,10 @@
 
 This document outlines the tasks required to port the C# application to a Dart/Flutter application.
 
+## Environment / Tooling Follow-ups
+
+- [ ] Install or provision Flutter/Dart SDK in CI/dev container so `flutter analyze` and widget tests can run during porting PRs.
+
 ## UI Port Plan (Flutter: Mobile, Desktop, Web)
 
 - [ ] Build and track the Flutter UI port as a first-class stream alongside backend model parity.
@@ -102,16 +106,16 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./DimensionLib/Model/UdtOutgoingConnection.cs`
 
-- [ ] Port `UdtOutgoingConnection.cs` to Dart
+- [x] Port `UdtOutgoingConnection.cs` to Dart
   - **Classes**:
-    - [ ] `class UdtOutgoingConnection`
+    - [x] `class UdtOutgoingConnection`
   - **Public Methods**:
-    - [ ] `send()`
+    - [x] `send()`
   - **Public Properties**:
-    - [ ] `connecting`
+    - [x] `connecting`
   - **TODO**:
     - [ ] Implement UDT via Dart FFI (wrapping C/C++ library) or rewrite using `RawDatagramSocket`. Currently, Dart implementations are stubs.
-    - [ ] Currently porting `dart-udt`; in the meantime, use a mock transport or mark related behavior as not implemented until the port is ready. Additional details will be added later.
+    - [x] Added a temporary pure-Dart `UdtTransport` abstraction and serializer-driven command flow so behavior can be unit tested with mocks while FFI/native transport is pending.
 
 ## File: `./DimensionLib/Model/OutgoingConnection.cs`
 

--- a/agents.md
+++ b/agents.md
@@ -22,3 +22,7 @@ This file contains instructions and context for agents working on this repositor
 - Temporary follow-up: command codec registration is intentionally externalized; wire all command types during app bootstrap once `App`/startup flow is fully Dart-native.
 - `lib/model/settings.dart` is now a pure-Dart implementation with an injected `StringKeyValueStore`, deterministic in-memory defaults, and explicit JSON handling for string-array settings.
 - Temporary follow-up: `Settings.save()` only persists when the injected backend implements `SavableStringKeyValueStore`; wire a disk-backed implementation during app bootstrap.
+
+- `lib/model/udt_connection.dart` now uses a pure-Dart `UdtTransport` abstraction plus injected `Serializer`, replacing throw-only stubs and enabling deterministic unit tests with in-memory/mock transports.
+- `lib/model/global_speed_limiter.dart` now supports injected settings lookup (`SpeedLimitProvider`) and configurable tick intervals so throttling behavior can be tested without filesystem/network dependencies.
+- Temporary follow-up: wire a production `UdtTransport` implementation (FFI or `RawDatagramSocket`) during bootstrap; current implementation intentionally focuses on command framing/callback behavior.

--- a/test/global_speed_limiter_test.dart
+++ b/test/global_speed_limiter_test.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+
+import 'package:dimension/model/global_speed_limiter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('returns full amount when limits are disabled', () async {
+    final limiter = GlobalSpeedLimiter();
+
+    final upload = await limiter.limitUpload(1024);
+    final download = await limiter.limitDownload(2048);
+
+    expect(upload, 1024);
+    expect(download, 2048);
+    limiter.dispose();
+  });
+
+  test('uses injected settings getter for upload and download limits', () async {
+    final values = <String, int>{
+      'Global Upload Rate Limit': 100,
+      'Global Download Rate Limit': 80,
+    };
+
+    final limiter = GlobalSpeedLimiter(
+      getInt: (key, defaultValue) => values[key] ?? defaultValue,
+      tickInterval: const Duration(milliseconds: 5),
+    );
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    final upload = await limiter.limitUpload(20);
+    final download = await limiter.limitDownload(20);
+
+    expect(upload, 10);
+    expect(download, 8);
+    limiter.dispose();
+  });
+}
+

--- a/test/udt_connection_test.dart
+++ b/test/udt_connection_test.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dimension/model/commands/command.dart';
+import 'package:dimension/model/serializer.dart';
+import 'package:dimension/model/udt_connection.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestCommand extends Command {
+  _TestCommand(this.value);
+
+  final String value;
+}
+
+class _FakeTransport implements UdtTransport {
+  final StreamController<Uint8List> _incomingController =
+      StreamController<Uint8List>.broadcast();
+  final List<Uint8List> sentPackets = <Uint8List>[];
+
+  @override
+  Stream<Uint8List> get incomingPackets => _incomingController.stream;
+
+  @override
+  bool isConnected = true;
+
+  @override
+  bool isConnecting = false;
+
+  @override
+  Future<void> close() async {
+    isConnected = false;
+    await _incomingController.close();
+  }
+
+  @override
+  Future<void> send(Uint8List packet) async {
+    sentPackets.add(packet);
+  }
+
+  Future<void> emit(Uint8List packet) => _incomingController.add(packet);
+}
+
+void main() {
+  Serializer buildSerializer() {
+    return Serializer()
+      ..register<_TestCommand>(
+        typeName: 'TestCommand',
+        encode: (command) => <String, dynamic>{'value': command.value},
+        decode: (json) => _TestCommand(json['value'] as String),
+      );
+  }
+
+  test('UdtOutgoingConnection send serializes through transport', () async {
+    final serializer = buildSerializer();
+    final transport = _FakeTransport();
+    final connection = UdtOutgoingConnection(
+      transport: transport,
+      serializer: serializer,
+    );
+
+    await connection.send(_TestCommand('ping'));
+
+    expect(transport.sentPackets, hasLength(1));
+    final decoded = serializer.deserialize(transport.sentPackets.single);
+    expect(decoded, isA<_TestCommand>());
+    expect((decoded as _TestCommand).value, 'ping');
+  });
+
+  test('UdtOutgoingConnection forwards inbound commands to callback', () async {
+    final serializer = buildSerializer();
+    final transport = _FakeTransport();
+    final completer = Completer<_TestCommand>();
+    final connection = UdtOutgoingConnection(
+      transport: transport,
+      serializer: serializer,
+    );
+
+    connection.commandReceived = (command) {
+      if (!completer.isCompleted && command is _TestCommand) {
+        completer.complete(command);
+      }
+    };
+
+    await transport.emit(serializer.serialize(_TestCommand('inbound')));
+
+    final received = await completer.future;
+    expect(received.value, 'inbound');
+  });
+
+  test('UdtIncomingConnection forwards inbound commands to callback', () async {
+    final serializer = buildSerializer();
+    final transport = _FakeTransport();
+    final completer = Completer<_TestCommand>();
+    final connection = UdtIncomingConnection(
+      transport: transport,
+      serializer: serializer,
+    );
+
+    connection.commandReceived = (command, _) {
+      if (!completer.isCompleted && command is _TestCommand) {
+        completer.complete(command);
+      }
+    };
+
+    await transport.emit(serializer.serialize(_TestCommand('hello')));
+
+    final received = await completer.future;
+    expect(received.value, 'hello');
+  });
+}
+


### PR DESCRIPTION
### Motivation

- Replace throw-only UDT stubs with a testable Dart-native transport so command framing and callbacks can be validated without native FFI or real networking.
- Make global speed limiting deterministic and unit-testable by removing hard-coded placeholder reads from `App.settings` and allowing an injected settings provider and tick interval.
- Add unit tests that exercise the new abstractions with in-memory fakes to make low-hanging-porting work verifiable without filesystem or network resources.
- Update tracking docs to reflect completed work and call out follow-ups (production UDT implementation and provisioning Flutter/Dart in CI).

### Description

- Added a `UdtTransport` abstraction and replaced the previous throw-only stubs with `UdtIncomingConnection` and `UdtOutgoingConnection` implementations that use an injected `Serializer` and the transport stream for inbound/outbound packets (`lib/model/udt_connection.dart`).
- Refactored `GlobalSpeedLimiter` to accept an injected `SpeedLimitProvider` and configurable `tickInterval` so limits can be mocked in tests (`lib/model/global_speed_limiter.dart`).
- Added unit tests that use in-memory fakes and the serializer to validate send/receive flows for UDT connections and verified limiter behavior (`test/udt_connection_test.dart`, `test/global_speed_limiter_test.dart`).
- Updated `TODO.md` and `agents.md` to mark the UDT outgoing connection work as addressed for now and to document the temporary bridge and CI/tooling follow-ups (`TODO.md`, `agents.md`).

### Testing

- Added unit tests (`test/udt_connection_test.dart`, `test/global_speed_limiter_test.dart`) that run with in-memory fakes and do not require network or disk access; they were added to the repo but not executed in this environment.
- Ran repository checks such as `git diff --check`, and committed the changes successfully.
- Attempted `flutter analyze` and `flutter test` in the container but both could not run because `flutter`/`dart` are not installed in this environment, so full automated test execution is pending in CI or a dev environment with Flutter/Dart provisioned.
- Follow-ups: wire a production `UdtTransport` implementation (FFI or `RawDatagramSocket`) during app bootstrap and provision Dart/Flutter in CI so the added tests can be executed as part of PR validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d0d99430832fbfdeca030f868275)