### PR TITLE
Port FlashWindow and LimitChangeDialog to Dart with mockable abstractions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -579,15 +579,17 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/FlashWindow.cs`
 
-- [ ] Port `FlashWindow.cs` to Dart
+- [x] Port `FlashWindow.cs` to Dart
   - **Classes**:
-    - [ ] `class FlashWindow`
+    - [x] `class FlashWindow`
   - **Public Methods**:
-    - [ ] `Flash()`
-    - [ ] `Flash()`
-    - [ ] `Start()`
-    - [ ] `Stop()`
-    - [ ] `ApplicationIsActivated()`
+    - [x] `Flash()`
+    - [x] `Flash()`
+    - [x] `Start()`
+    - [x] `Stop()`
+    - [x] `ApplicationIsActivated()`
+  - **TODO**:
+    - [ ] Hook a production `FlashWindowDriver` implementation into the Flutter desktop shell once `MainForm` is fully ported.
 
 ## File: `./Dimension/UI/DownloadQueuePanel.cs`
 
@@ -611,9 +613,11 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/LimitChangeDialog.cs`
 
-- [ ] Port `LimitChangeDialog.cs` to Dart
+- [x] Port `LimitChangeDialog.cs` to Dart
   - **Classes**:
-    - [ ] `class LimitChangeDialog`
+    - [x] `class LimitChangeDialog`
+  - **TODO**:
+    - [ ] Replace temporary `InMemorySpeedLimitSettings` usage with app-wide settings wiring when `SettingsForm` and `MainForm` are ported.
 
 ## File: `./Dimension/UI/DateFormatter.cs`
 

--- a/agents.md
+++ b/agents.md
@@ -26,3 +26,7 @@ This file contains instructions and context for agents working on this repositor
 - `lib/model/udt_connection.dart` now uses a pure-Dart `UdtTransport` abstraction plus injected `Serializer`, replacing throw-only stubs and enabling deterministic unit tests with in-memory/mock transports.
 - `lib/model/global_speed_limiter.dart` now supports injected settings lookup (`SpeedLimitProvider`) and configurable tick intervals so throttling behavior can be tested without filesystem/network dependencies.
 - Temporary follow-up: wire a production `UdtTransport` implementation (FFI or `RawDatagramSocket`) during bootstrap; current implementation intentionally focuses on command framing/callback behavior.
+- `lib/ui/flash_window.dart` is now a pure-Dart façade over an injectable `FlashWindowDriver`, so flash behavior can be mocked in tests without Win32 bindings.
+- Temporary follow-up: add a production desktop `FlashWindowDriver` (via platform channels or FFI) when the Flutter desktop shell is connected.
+- `lib/ui/limit_change_dialog.dart` is now a Flutter `AlertDialog` backed by pure-Dart conversion logic (`LimitChangeLogic`) and an injected `SpeedLimitSettings` abstraction for deterministic widget/unit tests.
+- Temporary follow-up: replace temporary in-memory settings wiring with real app settings once `MainForm`/`SettingsForm` Flutter ports are in place.

--- a/lib/ui/flash_window.dart
+++ b/lib/ui/flash_window.dart
@@ -1,188 +1,55 @@
-/*
- * Original C# Source File: Dimension/UI/FlashWindow.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Runtime.InteropServices;
-
-using System.Diagnostics;
-//from http://pietschsoft.com/post/2009/01/26/CSharp-Flash-Window-in-Taskbar-via-Win32-FlashWindowEx
-// and https://stackoverflow.com/questions/7162834/determine-if-current-application-is-activated-has-focus
-
-namespace Dimension.UI
-{
-    public static class FlashWindow
-    {
-        [DllImport("user32.dll")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool FlashWindowEx(ref FLASHWINFO pwfi);
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct FLASHWINFO
-        {
-            /// <summary>
-            /// The size of the structure in bytes.
-            /// </summary>
-            public uint cbSize;
-            /// <summary>
-            /// A Handle to the Window to be Flashed. The window can be either opened or minimized.
-            /// </summary>
-            public IntPtr hwnd;
-            /// <summary>
-            /// The Flash Status.
-            /// </summary>
-            public uint dwFlags;
-            /// <summary>
-            /// The number of times to Flash the window.
-            /// </summary>
-            public uint uCount;
-            /// <summary>
-            /// The rate at which the Window is to be flashed, in milliseconds. If Zero, the function uses the default cursor blink rate.
-            /// </summary>
-            public uint dwTimeout;
-        }
-
-        /// <summary>
-        /// Stop flashing. The system restores the window to its original stae.
-        /// </summary>
-        public const uint FLASHW_STOP = 0;
-
-        /// <summary>
-        /// Flash the window caption.
-        /// </summary>
-        public const uint FLASHW_CAPTION = 1;
-
-        /// <summary>
-        /// Flash the taskbar button.
-        /// </summary>
-        public const uint FLASHW_TRAY = 2;
-
-        /// <summary>
-        /// Flash both the window caption and taskbar button.
-        /// This is equivalent to setting the FLASHW_CAPTION | FLASHW_TRAY flags.
-        /// </summary>
-        public const uint FLASHW_ALL = 3;
-
-        /// <summary>
-        /// Flash continuously, until the FLASHW_STOP flag is set.
-        /// </summary>
-        public const uint FLASHW_TIMER = 4;
-
-        /// <summary>
-        /// Flash continuously until the window comes to the foreground.
-        /// </summary>
-        public const uint FLASHW_TIMERNOFG = 12;
-
-
-        /// <summary>
-        /// Flash the spacified Window (Form) until it recieves focus.
-        /// </summary>
-        /// <param name="form">The Form (Window) to Flash.</param>
-        /// <returns></returns>
-        public static bool Flash(System.Windows.Forms.Form form)
-        {
-            // Make sure we're running under Windows 2000 or later
-            if (Win2000OrLater)
-            {
-                FLASHWINFO fi = Create_FLASHWINFO(form.Handle, FLASHW_ALL | FLASHW_TIMERNOFG, uint.MaxValue, 0);
-                return FlashWindowEx(ref fi);
-            }
-            return false;
-        }
-
-        private static FLASHWINFO Create_FLASHWINFO(IntPtr handle, uint flags, uint count, uint timeout)
-        {
-            FLASHWINFO fi = new FLASHWINFO();
-            fi.cbSize = Convert.ToUInt32(Marshal.SizeOf(fi));
-            fi.hwnd = handle;
-            fi.dwFlags = flags;
-            fi.uCount = count;
-            fi.dwTimeout = timeout;
-            return fi;
-        }
-
-        /// <summary>
-        /// Flash the specified Window (form) for the specified number of times
-        /// </summary>
-        /// <param name="form">The Form (Window) to Flash.</param>
-        /// <param name="count">The number of times to Flash.</param>
-        /// <returns></returns>
-        public static bool Flash(System.Windows.Forms.Form form, uint count)
-        {
-            if (Win2000OrLater)
-            {
-                FLASHWINFO fi = Create_FLASHWINFO(form.Handle, FLASHW_ALL, count, 0);
-                return FlashWindowEx(ref fi);
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Start Flashing the specified Window (form)
-        /// </summary>
-        /// <param name="form">The Form (Window) to Flash.</param>
-        /// <returns></returns>
-        public static bool Start(System.Windows.Forms.Form form)
-        {
-            if (Win2000OrLater)
-            {
-                FLASHWINFO fi = Create_FLASHWINFO(form.Handle, FLASHW_ALL, uint.MaxValue, 0);
-                return FlashWindowEx(ref fi);
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Stop Flashing the specified Window (form)
-        /// </summary>
-        /// <param name="form"></param>
-        /// <returns></returns>
-        public static bool Stop(System.Windows.Forms.Form form)
-        {
-            if (Win2000OrLater)
-            {
-                FLASHWINFO fi = Create_FLASHWINFO(form.Handle, FLASHW_STOP, uint.MaxValue, 0);
-                return FlashWindowEx(ref fi);
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// A boolean value indicating whether the application is running on Windows 2000 or later.
-        /// </summary>
-        private static bool Win2000OrLater
-        {
-            get { return System.Environment.OSVersion.Version.Major >= 5; }
-        }
-
-
-
-        /// <summary>Returns true if the current application has focus, false otherwise</summary>
-        public static bool ApplicationIsActivated()
-        {
-            var activatedHandle = GetForegroundWindow();
-            if (activatedHandle == IntPtr.Zero)
-            {
-                return false;       // No window is currently activated
-            }
-
-            var procId = Process.GetCurrentProcess().Id;
-            int activeProcId;
-            GetWindowThreadProcessId(activatedHandle, out activeProcId);
-
-            return activeProcId == procId;
-        }
-
-
-        [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
-        private static extern IntPtr GetForegroundWindow();
-
-        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        private static extern int GetWindowThreadProcessId(IntPtr handle, out int processId);
-    }
+enum FlashType {
+  all,
 }
 
-*/
+abstract class FlashWindowDriver {
+  const FlashWindowDriver();
+
+  bool flash({int? count, FlashType type = FlashType.all});
+
+  bool start({FlashType type = FlashType.all});
+
+  bool stop();
+
+  bool applicationIsActivated();
+}
+
+class NoopFlashWindowDriver extends FlashWindowDriver {
+  const NoopFlashWindowDriver({this.isActivated = true});
+
+  final bool isActivated;
+
+  @override
+  bool applicationIsActivated() => isActivated;
+
+  @override
+  bool flash({int? count, FlashType type = FlashType.all}) => false;
+
+  @override
+  bool start({FlashType type = FlashType.all}) => false;
+
+  @override
+  bool stop() => false;
+}
+
+class FlashWindow {
+  static FlashWindowDriver driver = const NoopFlashWindowDriver();
+
+  static bool flash({int? count, FlashType type = FlashType.all}) {
+    return driver.flash(count: count, type: type);
+  }
+
+  static bool start({FlashType type = FlashType.all}) {
+    return driver.start(type: type);
+  }
+
+  static bool stop() {
+    return driver.stop();
+  }
+
+  static bool applicationIsActivated() {
+    return driver.applicationIsActivated();
+  }
+
+  const FlashWindow._();
+}

--- a/lib/ui/limit_change_dialog.dart
+++ b/lib/ui/limit_change_dialog.dart
@@ -1,119 +1,220 @@
-/*
- * Original C# Source File: Dimension/UI/LimitChangeDialog.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+import 'package:flutter/material.dart';
 
-namespace Dimension.UI
-{
-    public partial class LimitChangeDialog : Form
-    {
-        public enum WhichLimit
-        {
-            up,
-            down
-        }
-        WhichLimit whichLimit;
-        public LimitChangeDialog(WhichLimit whichLimit)
-        {
-            this.whichLimit = whichLimit;
-            InitializeComponent();
-            if (whichLimit == WhichLimit.up)
-                typeLabel.Text = "Global Upload Rate Limit:";
-            if (whichLimit == WhichLimit.down)
-                typeLabel.Text = "Global Download Rate Limit:";
+enum WhichLimit { up, down }
 
+abstract class SpeedLimitSettings {
+  int getLimitBytesPerSecond(WhichLimit whichLimit);
 
-            ulong value = 0;
-            if (whichLimit == WhichLimit.up)
-                value = App.settings.getULong("Global Upload Rate Limit", 0);
-            if (whichLimit == WhichLimit.down)
-                value = App.settings.getULong("Global Download Rate Limit", 0);
-
-            unitComboBox.SelectedIndex = 0;
-            if (value == 0)
-                noLimitButton.Checked = true;
-            else
-            {
-                yesLimitButton.Checked = true;
-                while (value > 1024)
-                {
-                    unitComboBox.SelectedIndex++;
-                    value /= 1024;
-                }
-                valueBox.Value = value;
-            }
-
-        }
-        private void cancelButton_Click(object sender, EventArgs e)
-        {
-            this.Close();
-        }
-        void saveAndClose()
-        {
-            ulong value = 0;
-
-            if (noLimitButton.Checked)
-                value = 0;
-            if (yesLimitButton.Checked)
-            {
-                value = (ulong)valueBox.Value;
-                for (int i = 0; i < unitComboBox.SelectedIndex; i++)
-                    value *= 1024;
-            }
-
-            if (whichLimit == WhichLimit.up)
-                App.settings.setULong("Global Upload Rate Limit", value);
-            if (whichLimit == WhichLimit.down)
-                App.settings.setULong("Global Download Rate Limit", value);
-            this.Close();
-        }
-
-        private void okayButton_Click(object sender, EventArgs e)
-        {
-            saveAndClose();
-        }
-
-        private void valueBox_ValueChanged(object sender, EventArgs e)
-        {
-            yesLimitButton.Checked = true;
-        }
-
-        private void unitComboBox_SelectedIndexChanged(object sender, EventArgs e)
-        {
-
-            yesLimitButton.Checked = true;
-        }
-
-        private void valueBox_KeyDown(object sender, KeyEventArgs e)
-        {
-            yesLimitButton.Checked = true;
-            if (e.KeyCode == Keys.Enter)
-            {
-                e.SuppressKeyPress = true;
-                saveAndClose();
-
-            }
-
-        }
-
-        private void LimitChangeDialog_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Enter)
-            {
-                e.SuppressKeyPress = true;
-                saveAndClose();
-
-            }
-        }
-    }
+  Future<void> setLimitBytesPerSecond(WhichLimit whichLimit, int value);
 }
 
-*/
+class InMemorySpeedLimitSettings extends SpeedLimitSettings {
+  final Map<WhichLimit, int> _values;
+
+  InMemorySpeedLimitSettings({Map<WhichLimit, int>? initialValues})
+    : _values = Map<WhichLimit, int>.from(initialValues ?? const {});
+
+  @override
+  int getLimitBytesPerSecond(WhichLimit whichLimit) => _values[whichLimit] ?? 0;
+
+  @override
+  Future<void> setLimitBytesPerSecond(WhichLimit whichLimit, int value) async {
+    _values[whichLimit] = value;
+  }
+}
+
+class LimitSelection {
+  const LimitSelection({
+    required this.noLimit,
+    required this.value,
+    required this.unitIndex,
+  });
+
+  final bool noLimit;
+  final int value;
+  final int unitIndex;
+}
+
+class LimitChangeLogic {
+  static const List<String> units = <String>['B/s', 'KB/s', 'MB/s', 'GB/s'];
+
+  static LimitSelection fromBytesPerSecond(int bytesPerSecond) {
+    if (bytesPerSecond <= 0) {
+      return const LimitSelection(noLimit: true, value: 0, unitIndex: 0);
+    }
+
+    var value = bytesPerSecond;
+    var unitIndex = 0;
+
+    while (value > 1024 && unitIndex < units.length - 1) {
+      value ~/= 1024;
+      unitIndex++;
+    }
+
+    return LimitSelection(noLimit: false, value: value, unitIndex: unitIndex);
+  }
+
+  static int toBytesPerSecond({
+    required bool noLimit,
+    required int value,
+    required int unitIndex,
+  }) {
+    if (noLimit) {
+      return 0;
+    }
+
+    var result = value;
+    for (var i = 0; i < unitIndex; i++) {
+      result *= 1024;
+    }
+    return result;
+  }
+
+  const LimitChangeLogic._();
+}
+
+class LimitChangeDialog extends StatefulWidget {
+  const LimitChangeDialog({
+    super.key,
+    required this.whichLimit,
+    required this.settings,
+  });
+
+  final WhichLimit whichLimit;
+  final SpeedLimitSettings settings;
+
+  static Future<void> show(
+    BuildContext context, {
+    required WhichLimit whichLimit,
+    required SpeedLimitSettings settings,
+  }) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) =>
+          LimitChangeDialog(whichLimit: whichLimit, settings: settings),
+    );
+  }
+
+  @override
+  State<LimitChangeDialog> createState() => _LimitChangeDialogState();
+}
+
+class _LimitChangeDialogState extends State<LimitChangeDialog> {
+  final TextEditingController _valueController = TextEditingController();
+
+  bool _noLimit = true;
+  int _unitIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = LimitChangeLogic.fromBytesPerSecond(
+      widget.settings.getLimitBytesPerSecond(widget.whichLimit),
+    );
+    _noLimit = initial.noLimit;
+    _unitIndex = initial.unitIndex;
+    _valueController.text = initial.value.toString();
+  }
+
+  @override
+  void dispose() {
+    _valueController.dispose();
+    super.dispose();
+  }
+
+  String get _title {
+    return widget.whichLimit == WhichLimit.up
+        ? 'Global Upload Rate Limit'
+        : 'Global Download Rate Limit';
+  }
+
+  Future<void> _saveAndClose() async {
+    final parsedValue = int.tryParse(_valueController.text) ?? 0;
+    final value = LimitChangeLogic.toBytesPerSecond(
+      noLimit: _noLimit,
+      value: parsedValue,
+      unitIndex: _unitIndex,
+    );
+
+    await widget.settings.setLimitBytesPerSecond(widget.whichLimit, value);
+    if (!mounted) {
+      return;
+    }
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(_title),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          RadioListTile<bool>(
+            title: const Text('No limit'),
+            value: true,
+            groupValue: _noLimit,
+            onChanged: (_) => setState(() => _noLimit = true),
+            contentPadding: EdgeInsets.zero,
+          ),
+          RadioListTile<bool>(
+            title: const Text('Use limit'),
+            value: false,
+            groupValue: _noLimit,
+            onChanged: (_) => setState(() => _noLimit = false),
+            contentPadding: EdgeInsets.zero,
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _valueController,
+                  enabled: !_noLimit,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: 'Value',
+                  ),
+                  onChanged: (_) {
+                    if (_noLimit) {
+                      setState(() => _noLimit = false);
+                    }
+                  },
+                ),
+              ),
+              const SizedBox(width: 12),
+              DropdownButton<int>(
+                value: _unitIndex,
+                items: [
+                  for (var i = 0; i < LimitChangeLogic.units.length; i++)
+                    DropdownMenuItem<int>(
+                      value: i,
+                      child: Text(LimitChangeLogic.units[i]),
+                    ),
+                ],
+                onChanged: _noLimit
+                    ? null
+                    : (index) {
+                        if (index != null) {
+                          setState(() => _unitIndex = index);
+                        }
+                      },
+              ),
+            ],
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _saveAndClose,
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}

--- a/test/flash_window_test.dart
+++ b/test/flash_window_test.dart
@@ -1,0 +1,51 @@
+import 'package:dimension/ui/flash_window.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _RecordingDriver extends FlashWindowDriver {
+  int flashCalls = 0;
+  int? flashCount;
+  int startCalls = 0;
+  int stopCalls = 0;
+
+  @override
+  bool applicationIsActivated() => false;
+
+  @override
+  bool flash({int? count, FlashType type = FlashType.all}) {
+    flashCalls++;
+    flashCount = count;
+    return true;
+  }
+
+  @override
+  bool start({FlashType type = FlashType.all}) {
+    startCalls++;
+    return true;
+  }
+
+  @override
+  bool stop() {
+    stopCalls++;
+    return true;
+  }
+}
+
+void main() {
+  test('delegates flash/start/stop and activation queries to configured driver', () {
+    final previousDriver = FlashWindow.driver;
+    final driver = _RecordingDriver();
+    FlashWindow.driver = driver;
+
+    expect(FlashWindow.applicationIsActivated(), isFalse);
+    expect(FlashWindow.flash(count: 3), isTrue);
+    expect(FlashWindow.start(), isTrue);
+    expect(FlashWindow.stop(), isTrue);
+
+    expect(driver.flashCalls, 1);
+    expect(driver.flashCount, 3);
+    expect(driver.startCalls, 1);
+    expect(driver.stopCalls, 1);
+
+    FlashWindow.driver = previousDriver;
+  });
+}

--- a/test/limit_change_dialog_test.dart
+++ b/test/limit_change_dialog_test.dart
@@ -1,0 +1,60 @@
+import 'package:dimension/ui/limit_change_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('converts bytes to limit selection and back', () {
+    final selection = LimitChangeLogic.fromBytesPerSecond(4096);
+
+    expect(selection.noLimit, isFalse);
+    expect(selection.value, 4);
+    expect(selection.unitIndex, 1);
+
+    final serialized = LimitChangeLogic.toBytesPerSecond(
+      noLimit: selection.noLimit,
+      value: selection.value,
+      unitIndex: selection.unitIndex,
+    );
+    expect(serialized, 4096);
+  });
+
+  testWidgets('saves selected rate limit to injected settings', (tester) async {
+    final settings = InMemorySpeedLimitSettings();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () {
+                LimitChangeDialog.show(
+                  context,
+                  whichLimit: WhichLimit.up,
+                  settings: settings,
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Use limit'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '2');
+    await tester.tap(find.text('B/s'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('KB/s').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(settings.getLimitBytesPerSecond(WhichLimit.up), 2048);
+  });
+}


### PR DESCRIPTION
### Motivation

- Replace commented C# UI stubs with idiomatic, pure-Dart implementations so UI behavior can be exercised and tested without Win32 or other platform bindings.  
- Provide injectable abstractions to keep desktop-specific behavior mockable during porting and CI until the Flutter desktop shell and platform drivers are available.  
- Deliver small, self-contained UI units (logic + widget) that are safe to run under widget/unit tests using in-memory dependencies.

### Description

- Implemented `lib/ui/flash_window.dart` with an injectable `FlashWindowDriver` abstraction, a `NoopFlashWindowDriver` default, and a `FlashWindow` facade exposing `flash`, `start`, `stop`, and `applicationIsActivated`.  
- Implemented `lib/ui/limit_change_dialog.dart` as a Flutter `AlertDialog` backed by `LimitChangeLogic` and an injectable `SpeedLimitSettings` API, plus `InMemorySpeedLimitSettings` for testing.  
- Added focused tests: `test/flash_window_test.dart` (driver delegation recording) and `test/limit_change_dialog_test.dart` (conversion logic and widget save flow).  
- Updated tracking/docs by marking the two C# UI items as ported and adding follow-up TODOs in `TODO.md` and porting notes in `agents.md`.

### Testing

- Added automated tests: `test/flash_window_test.dart` and `test/limit_change_dialog_test.dart` which exercise the new abstractions and widget flow.  
- Attempted to run formatting and Flutter/Dart tooling, but `dart`/`flutter` binaries are not available in the current environment so tests and formatting were not executed here (commands failed with `command not found`).  
- The tests are written to be deterministic with in-memory mocks and should pass when run in an environment with the Dart/Flutter SDK installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d22c8dc4832fb41d83e09a9e8710)