### PR TITLE
Port AboutForm, LoadingForm, and NetworkStatusPanel to Flutter widgets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -567,9 +567,9 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/AboutForm.cs`
 
-- [ ] Port `AboutForm.cs` to Dart
+- [x] Port `AboutForm.cs` to Dart
   - **Classes**:
-    - [ ] `class AboutForm`
+    - [x] `class AboutForm`
 
 ## File: `./Dimension/UI/DoubleBufferedListView.cs`
 
@@ -599,9 +599,11 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/LoadingForm.cs`
 
-- [ ] Port `LoadingForm.cs` to Dart
+- [x] Port `LoadingForm.cs` to Dart
   - **Classes**:
-    - [ ] `class LoadingForm`
+    - [x] `class LoadingForm`
+  - **TODO**:
+    - [ ] Wire `LoadingForm` to the final app bootstrap lifecycle once `App`/`MainForm` startup orchestration is fully ported.
 
 ## File: `./Dimension/UI/ByteFormatter.cs`
 
@@ -678,9 +680,11 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/NetworkStatusPanel.cs`
 
-- [ ] Port `NetworkStatusPanel.cs` to Dart
+- [x] Port `NetworkStatusPanel.cs` to Dart
   - **Classes**:
-    - [ ] `class NetworkStatusPanel`
+    - [x] `class NetworkStatusPanel`
+  - **TODO**:
+    - [ ] Replace temporary snapshot provider wiring with live `Core`/`Bootstrap` adapters when those Flutter-first surfaces are stabilized.
 
 ## File: `./Dimension/UI/CirclePanel.cs`
 

--- a/agents.md
+++ b/agents.md
@@ -30,3 +30,7 @@ This file contains instructions and context for agents working on this repositor
 - Temporary follow-up: add a production desktop `FlashWindowDriver` (via platform channels or FFI) when the Flutter desktop shell is connected.
 - `lib/ui/limit_change_dialog.dart` is now a Flutter `AlertDialog` backed by pure-Dart conversion logic (`LimitChangeLogic`) and an injected `SpeedLimitSettings` abstraction for deterministic widget/unit tests.
 - Temporary follow-up: replace temporary in-memory settings wiring with real app settings once `MainForm`/`SettingsForm` Flutter ports are in place.
+- `lib/ui/about_form.dart` is now a Flutter `AlertDialog`-based implementation with injectable app/version/description content so UI behavior stays testable without native resources.
+- `lib/ui/loading_form.dart` is now a pure-Dart/Flutter loading widget driven by an injected `LoadingStatusSource`, enabling deterministic polling/startup tests with mocks.
+- `lib/ui/network_status_panel.dart` is now a Flutter panel backed by injectable snapshot/provider abstractions plus pure formatter helpers for deterministic unit/widget tests.
+- Temporary follow-up: connect `LoadingStatusSource` and `NetworkStatusProvider` to real app bootstrap/core adapters once `App` and `MainForm` orchestration is fully ported.

--- a/lib/ui/about_form.dart
+++ b/lib/ui/about_form.dart
@@ -1,30 +1,61 @@
-/*
- * Original C# Source File: Dimension/UI/AboutForm.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+import 'package:flutter/material.dart';
 
-namespace Dimension.UI
-{
-    public partial class AboutForm : Form
-    {
-        public AboutForm()
-        {
-            InitializeComponent();
-        }
+class AboutForm extends StatelessWidget {
+  const AboutForm({
+    super.key,
+    this.applicationName = 'Dimension',
+    this.versionLabel = '',
+    this.description =
+        'A Flutter port of the Dimension peer-to-peer client.',
+  });
 
-        private void button1_Click(object sender, EventArgs e)
-        {
-            this.Close();
-        }
-    }
+  final String applicationName;
+  final String versionLabel;
+  final String description;
+
+  static Future<void> show(
+    BuildContext context, {
+    String applicationName = 'Dimension',
+    String versionLabel = '',
+    String description =
+        'A Flutter port of the Dimension peer-to-peer client.',
+  }) {
+    return showDialog<void>(
+      context: context,
+      builder: (_) => AboutForm(
+        applicationName: applicationName,
+        versionLabel: versionLabel,
+        description: description,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('About $applicationName'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            applicationName,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          if (versionLabel.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(versionLabel),
+          ],
+          const SizedBox(height: 12),
+          Text(description),
+        ],
+      ),
+      actions: [
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
 }
-
-*/

--- a/lib/ui/loading_form.dart
+++ b/lib/ui/loading_form.dart
@@ -1,40 +1,91 @@
-/*
- * Original C# Source File: Dimension/UI/LoadingForm.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+import 'dart:async';
 
-namespace Dimension
-{
-    public partial class LoadingForm : Form
-    {
-        public LoadingForm()
-        {
-            InitializeComponent();
-        }
+import 'package:flutter/material.dart';
 
-        bool started = false;
-        private void loadTimer_Tick(object sender, EventArgs e)
-        {
-            if (!started)
-            {
-                started = true;
-                System.Threading.Thread t = new System.Threading.Thread(App.doLoad);
-                t.Name = "Loading Thread";
-                t.Start();
-            }
-            label1.Text = "Dimension - " + Model.SystemLog.lastLine;
-            if (App.doneLoading)
-                this.Close();
-            }
-    }
+abstract class LoadingStatusSource {
+  String get statusLine;
+
+  bool get isDone;
+
+  Future<void> startLoading();
 }
 
-*/
+class LoadingForm extends StatefulWidget {
+  const LoadingForm({
+    super.key,
+    required this.statusSource,
+    this.title = 'Dimension',
+    this.pollInterval = const Duration(milliseconds: 200),
+    this.onFinished,
+  });
+
+  final LoadingStatusSource statusSource;
+  final String title;
+  final Duration pollInterval;
+  final VoidCallback? onFinished;
+
+  @override
+  State<LoadingForm> createState() => _LoadingFormState();
+}
+
+class _LoadingFormState extends State<LoadingForm> {
+  Timer? _pollTimer;
+  var _started = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _pollTimer = Timer.periodic(widget.pollInterval, (_) => _tick());
+  }
+
+  Future<void> _tick() async {
+    if (!_started) {
+      _started = true;
+      await widget.statusSource.startLoading();
+      if (!mounted) {
+        return;
+      }
+      setState(() {});
+    }
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {});
+
+    if (widget.statusSource.isDone) {
+      _pollTimer?.cancel();
+      widget.onFinished?.call();
+    }
+  }
+
+  @override
+  void dispose() {
+    _pollTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(
+                height: 24,
+                width: 24,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+              const SizedBox(height: 12),
+              Text('${widget.title} - ${widget.statusSource.statusLine}'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/network_status_panel.dart
+++ b/lib/ui/network_status_panel.dart
@@ -1,91 +1,207 @@
-/*
- * Original C# Source File: Dimension/UI/NetworkStatusPanel.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+import 'package:dimension/ui/byte_formatter.dart';
+import 'package:flutter/material.dart';
 
-namespace Dimension.UI
-{
-    public partial class NetworkStatusPanel : UserControl
-    {
-        public NetworkStatusPanel()
-        {
-            InitializeComponent();
-            update();
-        }
-        private void updateTimer_Tick(object sender, EventArgs e)
-        {
-            update();
-        }
-        void updateFont()
-        {
-            eventsBox.Font = App.getFont();
-            portsTextBox.Font = App.getFont();
-            trafficBox.Font = App.getFont();
-            systemLogBox.Font = App.getFont();
-        }
+class NetworkPortsInfo {
+  const NetworkPortsInfo({
+    required this.internalIpAddresses,
+    required this.externalIpAddress,
+    required this.internalTcpPort,
+    required this.externalTcpPort,
+    required this.internalUdpPort,
+    required this.externalUdpPort,
+    required this.internalKademliaPort,
+    required this.externalKademliaPort,
+  });
 
-        void update()
-        {
-            string s = "";
-
-            s += "Internal IP Addresses: ";
-            foreach (System.Net.IPAddress a in App.theCore.internalIPs)
-                s += a.ToString() + " ";
-            s += Environment.NewLine;
-            s += "External IP Address: " + App.bootstrap.publicDataEndPoint.Address.ToString() + Environment.NewLine;
-
-            s += "Internal TCP Port: " + App.bootstrap.internalDataPort.ToString() + Environment.NewLine;
-            s += "External TCP Port: " + App.bootstrap.publicDataEndPoint.Port.ToString() + Environment.NewLine;
-
-            s += "Internal UDP Port: " + App.bootstrap.internalControlPort.ToString() + Environment.NewLine;
-            s += "External UDP Port: " + App.bootstrap.publicControlEndPoint.Port.ToString() + Environment.NewLine;
-
-            s += "Internal Kademlia (UDP) Port: " + App.bootstrap.internalDHTPort.ToString() + Environment.NewLine;
-            s += "External Kademlia (UDP) Port: " + App.bootstrap.publicDHTPort.ToString() + Environment.NewLine;
-            
-
-            portsTextBox.Text = s;
-
-            s = "";
-            s += "Successful UDP command receives from other machines: " + App.theCore.udpCommandsNotFromUs.ToString() + Environment.NewLine;
-            s += "Successful incoming TCP connections: " + App.theCore.incomingTcpConnections.ToString() + Environment.NewLine;
-            s += "Successful incoming UDT connections: " + App.theCore.incomingUdtConnections.ToString() + Environment.NewLine;
-            s += "Successful outgoing TCP connections: " + Model.ReliableOutgoingConnection.successfulConnections + Environment.NewLine;
-            s += "Successful outgoing UDT connections: " + Model.UdtOutgoingConnection.successfulConnections.ToString() + Environment.NewLine;
-
-
-            eventsBox.Text = s;
-
-            s = "*** Protocol Traffic Analysis ***" + Environment.NewLine;
-            s += "(Excluding bulk data such as file transfers)" + Environment.NewLine;
-            s += Environment.NewLine;
-            s += "*** Incoming ***" + Environment.NewLine;
-            lock (App.theCore.incomingTraffic)
-                foreach (string t in App.theCore.incomingTraffic.Keys)
-                    s += t + ": " + ByteFormatter.formatBytes(App.theCore.incomingTraffic[t]) + Environment.NewLine;
-
-            s += Environment.NewLine;
-            s += "*** Outgoing ***" + Environment.NewLine;
-            lock (App.theCore.outgoingTraffic)
-                foreach (string t in App.theCore.outgoingTraffic.Keys)
-                    s += t + ": " + ByteFormatter.formatBytes(App.theCore.outgoingTraffic[t]) + Environment.NewLine;
-
-            trafficBox.Text = s;
-
-
-            systemLogBox.Text = Model.SystemLog.theLog;
-
-            updateFont();
-        }
-    }
+  final List<String> internalIpAddresses;
+  final String externalIpAddress;
+  final int internalTcpPort;
+  final int externalTcpPort;
+  final int internalUdpPort;
+  final int externalUdpPort;
+  final int internalKademliaPort;
+  final int externalKademliaPort;
 }
 
-*/
+class NetworkEventsInfo {
+  const NetworkEventsInfo({
+    required this.udpCommandsNotFromUs,
+    required this.incomingTcpConnections,
+    required this.incomingUdtConnections,
+    required this.successfulOutgoingTcpConnections,
+    required this.successfulOutgoingUdtConnections,
+  });
+
+  final int udpCommandsNotFromUs;
+  final int incomingTcpConnections;
+  final int incomingUdtConnections;
+  final int successfulOutgoingTcpConnections;
+  final int successfulOutgoingUdtConnections;
+}
+
+class NetworkStatusSnapshot {
+  const NetworkStatusSnapshot({
+    required this.ports,
+    required this.events,
+    required this.incomingTrafficByCommand,
+    required this.outgoingTrafficByCommand,
+    required this.systemLog,
+  });
+
+  final NetworkPortsInfo ports;
+  final NetworkEventsInfo events;
+  final Map<String, int> incomingTrafficByCommand;
+  final Map<String, int> outgoingTrafficByCommand;
+  final String systemLog;
+}
+
+abstract class NetworkStatusProvider {
+  NetworkStatusSnapshot get snapshot;
+}
+
+class NetworkStatusFormatter {
+  static String formatPorts(NetworkPortsInfo ports) {
+    final buffer = StringBuffer()
+      ..writeln('Internal IP Addresses: ${ports.internalIpAddresses.join(' ')}')
+      ..writeln('External IP Address: ${ports.externalIpAddress}')
+      ..writeln('Internal TCP Port: ${ports.internalTcpPort}')
+      ..writeln('External TCP Port: ${ports.externalTcpPort}')
+      ..writeln('Internal UDP Port: ${ports.internalUdpPort}')
+      ..writeln('External UDP Port: ${ports.externalUdpPort}')
+      ..writeln('Internal Kademlia (UDP) Port: ${ports.internalKademliaPort}')
+      ..write('External Kademlia (UDP) Port: ${ports.externalKademliaPort}');
+
+    return buffer.toString();
+  }
+
+  static String formatEvents(NetworkEventsInfo events) {
+    final buffer = StringBuffer()
+      ..writeln(
+        'Successful UDP command receives from other machines: '
+        '${events.udpCommandsNotFromUs}',
+      )
+      ..writeln(
+        'Successful incoming TCP connections: ${events.incomingTcpConnections}',
+      )
+      ..writeln(
+        'Successful incoming UDT connections: ${events.incomingUdtConnections}',
+      )
+      ..writeln(
+        'Successful outgoing TCP connections: '
+        '${events.successfulOutgoingTcpConnections}',
+      )
+      ..write(
+        'Successful outgoing UDT connections: '
+        '${events.successfulOutgoingUdtConnections}',
+      );
+
+    return buffer.toString();
+  }
+
+  static String formatTraffic({
+    required Map<String, int> incoming,
+    required Map<String, int> outgoing,
+  }) {
+    final buffer = StringBuffer()
+      ..writeln('*** Protocol Traffic Analysis ***')
+      ..writeln('(Excluding bulk data such as file transfers)')
+      ..writeln()
+      ..writeln('*** Incoming ***');
+
+    for (final entry in incoming.entries) {
+      buffer.writeln('${entry.key}: ${ByteFormatter.formatBytes(entry.value)}');
+    }
+
+    buffer
+      ..writeln()
+      ..writeln('*** Outgoing ***');
+
+    for (final entry in outgoing.entries) {
+      buffer.writeln('${entry.key}: ${ByteFormatter.formatBytes(entry.value)}');
+    }
+
+    return buffer.toString().trimRight();
+  }
+
+  const NetworkStatusFormatter._();
+}
+
+class NetworkStatusPanel extends StatelessWidget {
+  const NetworkStatusPanel({super.key, required this.provider});
+
+  final NetworkStatusProvider provider;
+
+  @override
+  Widget build(BuildContext context) {
+    final snapshot = provider.snapshot;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compact = constraints.maxWidth < 900;
+        final sections = [
+          _InfoSection(
+            title: 'Ports',
+            text: NetworkStatusFormatter.formatPorts(snapshot.ports),
+          ),
+          _InfoSection(
+            title: 'Events',
+            text: NetworkStatusFormatter.formatEvents(snapshot.events),
+          ),
+          _InfoSection(
+            title: 'Traffic',
+            text: NetworkStatusFormatter.formatTraffic(
+              incoming: snapshot.incomingTrafficByCommand,
+              outgoing: snapshot.outgoingTrafficByCommand,
+            ),
+          ),
+          _InfoSection(
+            title: 'System Log',
+            text: snapshot.systemLog,
+          ),
+        ];
+
+        if (compact) {
+          return ListView(
+            padding: const EdgeInsets.all(12),
+            children: sections,
+          );
+        }
+
+        return GridView.count(
+          crossAxisCount: 2,
+          childAspectRatio: 1.9,
+          padding: const EdgeInsets.all(12),
+          children: sections,
+        );
+      },
+    );
+  }
+}
+
+class _InfoSection extends StatelessWidget {
+  const _InfoSection({required this.title, required this.text});
+
+  final String title;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Expanded(
+              child: SingleChildScrollView(
+                child: SelectableText(text),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/ui_port_widgets_test.dart
+++ b/test/ui_port_widgets_test.dart
@@ -1,0 +1,136 @@
+import 'package:dimension/ui/about_form.dart';
+import 'package:dimension/ui/loading_form.dart';
+import 'package:dimension/ui/network_status_panel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeLoadingStatusSource implements LoadingStatusSource {
+  var startCalls = 0;
+  var _done = false;
+
+  @override
+  bool get isDone => _done;
+
+  @override
+  String get statusLine => _done ? 'Ready' : 'Loading';
+
+  @override
+  Future<void> startLoading() async {
+    startCalls++;
+    _done = true;
+  }
+}
+
+class _FakeNetworkStatusProvider implements NetworkStatusProvider {
+  @override
+  NetworkStatusSnapshot get snapshot =>
+      const NetworkStatusSnapshot(
+        ports: NetworkPortsInfo(
+          internalIpAddresses: ['192.168.1.10'],
+          externalIpAddress: '44.55.66.77',
+          internalTcpPort: 1001,
+          externalTcpPort: 2001,
+          internalUdpPort: 1002,
+          externalUdpPort: 2002,
+          internalKademliaPort: 1003,
+          externalKademliaPort: 2003,
+        ),
+        events: NetworkEventsInfo(
+          udpCommandsNotFromUs: 8,
+          incomingTcpConnections: 9,
+          incomingUdtConnections: 10,
+          successfulOutgoingTcpConnections: 11,
+          successfulOutgoingUdtConnections: 12,
+        ),
+        incomingTrafficByCommand: {'HelloCommand': 2048},
+        outgoingTrafficByCommand: {'SearchResultCommand': 3072},
+        systemLog: 'system ok',
+      );
+}
+
+void main() {
+  testWidgets('about form renders and closes', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: AboutForm(
+            applicationName: 'Dimension',
+            versionLabel: '1.2.3',
+            description: 'About text',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('About Dimension'), findsOneWidget);
+    expect(find.text('1.2.3'), findsOneWidget);
+    expect(find.text('About text'), findsOneWidget);
+  });
+
+  testWidgets('loading form starts once and triggers completion callback', (
+    tester,
+  ) async {
+    final source = _FakeLoadingStatusSource();
+    var finishedCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: LoadingForm(
+            statusSource: source,
+            pollInterval: const Duration(milliseconds: 10),
+            onFinished: () {
+              finishedCalls++;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump(const Duration(milliseconds: 20));
+
+    expect(source.startCalls, 1);
+    expect(finishedCalls, 1);
+    expect(find.textContaining('Dimension - Ready'), findsOneWidget);
+  });
+
+  test('network status formatter includes key values', () {
+    final portsText = NetworkStatusFormatter.formatPorts(
+      const NetworkPortsInfo(
+        internalIpAddresses: ['127.0.0.1', '192.168.1.2'],
+        externalIpAddress: '11.12.13.14',
+        internalTcpPort: 999,
+        externalTcpPort: 1999,
+        internalUdpPort: 888,
+        externalUdpPort: 1888,
+        internalKademliaPort: 777,
+        externalKademliaPort: 1777,
+      ),
+    );
+    expect(portsText, contains('11.12.13.14'));
+    expect(portsText, contains('External Kademlia (UDP) Port: 1777'));
+
+    final trafficText = NetworkStatusFormatter.formatTraffic(
+      incoming: const {'HelloCommand': 2048},
+      outgoing: const {'SearchCommand': 4096},
+    );
+    expect(trafficText, contains('HelloCommand: 2.0KB'));
+    expect(trafficText, contains('SearchCommand: 4.0KB'));
+  });
+
+  testWidgets('network status panel renders all sections', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: NetworkStatusPanel(provider: _FakeNetworkStatusProvider()),
+        ),
+      ),
+    );
+
+    expect(find.text('Ports'), findsOneWidget);
+    expect(find.text('Events'), findsOneWidget);
+    expect(find.text('Traffic'), findsOneWidget);
+    expect(find.text('System Log'), findsOneWidget);
+    expect(find.textContaining('system ok'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
### Motivation
- Replace comment-only C# UI placeholders with idiomatic, testable Flutter widgets so UI behavior can be developed and validated without native platform resources. 
- Keep UI code pure-Dart and dependency-injectable so startup and network-related behavior can be mocked for deterministic tests.

### Description
- Implemented `AboutForm` as a Flutter `AlertDialog` with injectable `applicationName`, `versionLabel`, `description`, and a `show(...)` helper in `lib/ui/about_form.dart`.
- Implemented `LoadingForm` as a poll-driven Flutter widget with an injected `LoadingStatusSource`, configurable `pollInterval`, and an `onFinished` callback in `lib/ui/loading_form.dart`.
- Rewrote `NetworkStatusPanel` to use pure-Dart data contracts (`NetworkPortsInfo`, `NetworkEventsInfo`, `NetworkStatusSnapshot`) and `NetworkStatusProvider`, added `NetworkStatusFormatter` helpers and a responsive panel layout in `lib/ui/network_status_panel.dart`.
- Added widget/unit tests in `test/ui_port_widgets_test.dart` covering About dialog rendering, loading flow start/completion (with a fake `LoadingStatusSource`), network status formatter output, and panel rendering with a fake `NetworkStatusProvider`.
- Updated `TODO.md` to mark the three UI ports done and added follow-up TODOs for runtime wiring, and updated `agents.md` with notes about the new adapters and integration follow-ups.

### Testing
- Ran `git diff --check`, which passed cleanly.
- Added `test/ui_port_widgets_test.dart` covering the new widgets and formatters, but could not execute `flutter analyze` or `flutter test` in this environment because the `flutter` CLI/SDK is not installed (both commands were attempted and blocked). 
- Recommendation: run `flutter analyze` and `flutter test` in CI or a dev environment with Flutter installed to verify static analysis and execute the widget tests (they are written to use mocks/fakes and do not require network/filesystem access).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d38a0324832f93823e8136c1646d)