### PR TITLE
Port low-hanging UI stubs to pure Flutter widgets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -573,9 +573,9 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/DoubleBufferedListView.cs`
 
-- [ ] Port `DoubleBufferedListView.cs` to Dart
+- [x] Port `DoubleBufferedListView.cs` to Dart
   - **Classes**:
-    - [ ] `class DoubleBufferedListView`
+    - [x] `class DoubleBufferedListView`
 
 ## File: `./Dimension/UI/FlashWindow.cs`
 
@@ -593,9 +593,11 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/DownloadQueuePanel.cs`
 
-- [ ] Port `DownloadQueuePanel.cs` to Dart
+- [x] Port `DownloadQueuePanel.cs` to Dart
   - **Classes**:
-    - [ ] `class DownloadQueuePanel`
+    - [x] `class DownloadQueuePanel`
+  - **TODO**:
+    - [ ] Replace temporary empty-state panel with live queued-transfer data once `TransfersPanel` wiring is ported.
 
 ## File: `./Dimension/UI/LoadingForm.cs`
 
@@ -631,11 +633,13 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/HTMLPanel.cs`
 
-- [ ] Port `HTMLPanel.cs` to Dart
+- [x] Port `HTMLPanel.cs` to Dart
   - **Classes**:
-    - [ ] `class HTMLPanel`
+    - [x] `class HTMLPanel`
   - **Public Properties**:
-    - [ ] `isMono`
+    - [x] `isMono`
+  - **TODO**:
+    - [ ] Hook `HTMLPanel` join-circle callbacks into the final `JoinCircleForm`/`MainForm` flow once those Flutter ports are in place.
 
 ## File: `./Dimension/UI/SettingsForm.cs`
 
@@ -667,9 +671,9 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/RenameShareForm.cs`
 
-- [ ] Port `RenameShareForm.cs` to Dart
+- [x] Port `RenameShareForm.cs` to Dart
   - **Classes**:
-    - [ ] `class RenameShareForm`
+    - [x] `class RenameShareForm`
 
 ## File: `./Dimension/UI/SearchPanel.cs`
 

--- a/agents.md
+++ b/agents.md
@@ -33,4 +33,7 @@ This file contains instructions and context for agents working on this repositor
 - `lib/ui/about_form.dart` is now a Flutter `AlertDialog`-based implementation with injectable app/version/description content so UI behavior stays testable without native resources.
 - `lib/ui/loading_form.dart` is now a pure-Dart/Flutter loading widget driven by an injected `LoadingStatusSource`, enabling deterministic polling/startup tests with mocks.
 - `lib/ui/network_status_panel.dart` is now a Flutter panel backed by injectable snapshot/provider abstractions plus pure formatter helpers for deterministic unit/widget tests.
+- `lib/ui/html_panel.dart` is now a pure Flutter panel with explicit `dimensionbootstrap://` / `dimensionlan://` parsing and injectable join callbacks, so link-handling behavior is unit/widget testable without networking.
+- `lib/ui/rename_share_form.dart`, `lib/ui/double_buffered_list_view.dart`, and `lib/ui/download_queue_panel.dart` are now pure Flutter ports with deterministic widget behavior and no WinForms dependencies.
+- Temporary follow-up: wire `HTMLPanel` and `DownloadQueuePanel` to `MainForm`/transfer state adapters once those larger UI surfaces are fully ported.
 - Temporary follow-up: connect `LoadingStatusSource` and `NetworkStatusProvider` to real app bootstrap/core adapters once `App` and `MainForm` orchestration is fully ported.

--- a/lib/ui/double_buffered_list_view.dart
+++ b/lib/ui/double_buffered_list_view.dart
@@ -1,21 +1,31 @@
-/*
- * Original C# Source File: Dimension/UI/DoubleBufferedListView.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+import 'package:flutter/material.dart';
 
-namespace Dimension.UI
-{
-    public class DoubleBufferedListView :System.Windows.Forms.ListView
-    {
-        public DoubleBufferedListView()
-        {
-            DoubleBuffered = true;
-        }
-        }
+/// Flutter replacement for the WinForms `DoubleBufferedListView`.
+///
+/// Flutter already paints with a retained, GPU-accelerated pipeline, so
+/// explicit double buffering is not needed. This widget wraps a lazily built
+/// list and keeps API usage simple for the ongoing UI port.
+class DoubleBufferedListView extends StatelessWidget {
+  const DoubleBufferedListView({
+    super.key,
+    required this.itemCount,
+    required this.itemBuilder,
+    this.padding,
+    this.controller,
+  });
+
+  final int itemCount;
+  final IndexedWidgetBuilder itemBuilder;
+  final EdgeInsetsGeometry? padding;
+  final ScrollController? controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      controller: controller,
+      padding: padding,
+      itemCount: itemCount,
+      itemBuilder: itemBuilder,
+    );
+  }
 }
-
-*/

--- a/lib/ui/download_queue_panel.dart
+++ b/lib/ui/download_queue_panel.dart
@@ -1,25 +1,17 @@
-/*
- * Original C# Source File: Dimension/UI/DownloadQueuePanel.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+import 'package:flutter/material.dart';
 
-namespace Dimension.UI
-{
-    public partial class DownloadQueuePanel : UserControl
-    {
-        public DownloadQueuePanel()
-        {
-            InitializeComponent();
-        }
-    }
+class DownloadQueuePanel extends StatelessWidget {
+  const DownloadQueuePanel({super.key, this.emptyMessage = 'No queued downloads.'});
+
+  final String emptyMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        emptyMessage,
+        style: Theme.of(context).textTheme.bodyMedium,
+      ),
+    );
+  }
 }
-
-*/

--- a/lib/ui/html_panel.dart
+++ b/lib/ui/html_panel.dart
@@ -1,68 +1,124 @@
-/*
- * Original C# Source File: Dimension/UI/HTMLPanel.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
-namespace Dimension.UI
-{
-    public partial class HTMLPanel : UserControl
-    {
+enum JoinCircleType { bootstrap, lan }
 
-        public static bool isMono
-        {
-            get
-            {
-                return Type.GetType("Mono.Runtime") != null;
-            }
-        }
+class JoinCircleRequest {
+  const JoinCircleRequest({required this.url, required this.type});
 
-        public HTMLPanel()
-        {
-            InitializeComponent();
-
-        }
-        void error(object sender, TheArtOfDev.HtmlRenderer.Core.Entities.HtmlRenderErrorEventArgs e)
-        {
-
-        }
-        void navigate(object sender, TheArtOfDev.HtmlRenderer.Core.Entities.HtmlLinkClickedEventArgs e)
-        {
-            if (e.Link.ToLower().StartsWith("dimensionbootstrap://"))
-            {
-                e.Handled = true;
-                string s = e.Link;
-                s = "http://" + s.Substring("DimensionBootstrap://".Length);
-                UI.JoinCircleForm.joinCircle(s, JoinCircleForm.CircleType.bootstrap);
-            }
-            if (e.Link.ToLower().StartsWith("dimensionlan://"))
-            {
-                e.Handled = true;
-                string s = e.Link;
-                s = "http://" + s.Substring("DimensionLAN://".Length);
-                UI.JoinCircleForm.joinCircle(s, JoinCircleForm.CircleType.LAN);
-            }
-        }
-
-        private void HTMLPanel_Load(object sender, EventArgs e)
-        {
-            string text = "<!DOCTYPE html><html><head><title>Dimension</title></head><body><h1>Welcome to Dimension!</h1><p>It's still young, so there aren't many networks to join. Check these ones out:</p><h2>List of Bootstraps</h2><ul><li><a href='DimensionBootstrap://www.9thcircle.net/Projects/Dimension/bootstrap.php'>9th Circle Test Bootstrap</a></li><li><a href='DimensionBootstrap://www.respawn.com.au/dimension.php'>Respawn LAN Bootstrap</a></li><li><a href='DimensionLAN://LAN'>Your local network</a></li></ul></body></html>";
-
-            var p = new TheArtOfDev.HtmlRenderer.WinForms.HtmlPanel();
-            p.Dock = DockStyle.Fill;
-            p.BaseStylesheet = "h1{color:black;}";
-            p.Text = text;
-            p.LinkClicked += navigate;
-            Controls.Add(p);
-        }
-    }
+  final String url;
+  final JoinCircleType type;
 }
 
-*/
+JoinCircleRequest? parseDimensionJoinLink(String rawLink) {
+  final normalized = rawLink.trim();
+  final lower = normalized.toLowerCase();
+
+  const bootstrapPrefix = 'dimensionbootstrap://';
+  const lanPrefix = 'dimensionlan://';
+
+  if (lower.startsWith(bootstrapPrefix)) {
+    final host = normalized.substring(bootstrapPrefix.length);
+    return JoinCircleRequest(
+      url: 'http://$host',
+      type: JoinCircleType.bootstrap,
+    );
+  }
+
+  if (lower.startsWith(lanPrefix)) {
+    final host = normalized.substring(lanPrefix.length);
+    return JoinCircleRequest(
+      url: 'http://$host',
+      type: JoinCircleType.lan,
+    );
+  }
+
+  return null;
+}
+
+class HTMLPanel extends StatelessWidget {
+  const HTMLPanel({super.key, this.onJoinCircle});
+
+  final ValueChanged<JoinCircleRequest>? onJoinCircle;
+
+  static bool get isMono => !kIsWeb && (defaultTargetPlatform == TargetPlatform.linux);
+
+  static const bootstrapPrimaryLink =
+      'DimensionBootstrap://www.9thcircle.net/Projects/Dimension/bootstrap.php';
+  static const bootstrapSecondaryLink =
+      'DimensionBootstrap://www.respawn.com.au/dimension.php';
+  static const lanLink = 'DimensionLAN://LAN';
+
+  void _handleTap(String rawLink) {
+    final request = parseDimensionJoinLink(rawLink);
+    if (request != null) {
+      onJoinCircle?.call(request);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Welcome to Dimension!', style: Theme.of(context).textTheme.headlineSmall),
+            const SizedBox(height: 8),
+            const Text(
+              "It's still young, so there aren't many networks to join. Check these ones out:",
+            ),
+            const SizedBox(height: 16),
+            Text('List of Bootstraps', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            _JoinLinkRow(
+              label: '9th Circle Test Bootstrap',
+              rawLink: bootstrapPrimaryLink,
+              onTap: _handleTap,
+            ),
+            _JoinLinkRow(
+              label: 'Respawn LAN Bootstrap',
+              rawLink: bootstrapSecondaryLink,
+              onTap: _handleTap,
+            ),
+            _JoinLinkRow(
+              label: 'Your local network',
+              rawLink: lanLink,
+              onTap: _handleTap,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _JoinLinkRow extends StatelessWidget {
+  const _JoinLinkRow({
+    required this.label,
+    required this.rawLink,
+    required this.onTap,
+  });
+
+  final String label;
+  final String rawLink;
+  final ValueChanged<String> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: InkWell(
+        onTap: () => onTap(rawLink),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.primary,
+            decoration: TextDecoration.underline,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/rename_share_form.dart
+++ b/lib/ui/rename_share_form.dart
@@ -1,56 +1,58 @@
-/*
- * Original C# Source File: Dimension/UI/RenameShareForm.cs
- *
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
+import 'package:flutter/material.dart';
 
-namespace Dimension.UI
-{
-    public partial class RenameShareForm : Form
-    {
-        public string theName;
-        public RenameShareForm(string theName)
-        {
-            InitializeComponent();
-            this.theName = theName;
-            textBox1.Text = theName;
-        }
+class RenameShareForm extends StatefulWidget {
+  const RenameShareForm({super.key, required this.initialName});
 
-        private void okayButton_Click(object sender, EventArgs e)
-        {
-            theName = textBox1.Text;
-            Close();
-        }
+  final String initialName;
 
-        private void textBox1_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Enter)
-            {
-                e.SuppressKeyPress = true;
+  static Future<String?> show(BuildContext context, {required String initialName}) {
+    return showDialog<String>(
+      context: context,
+      builder: (_) => RenameShareForm(initialName: initialName),
+    );
+  }
 
-                theName = textBox1.Text;
-                Close();
-            }
-        }
-
-        private void RenameShareForm_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.Enter)
-            {
-                e.SuppressKeyPress = true;
-
-                theName = textBox1.Text;
-                Close();
-            }
-        }
-    }
+  @override
+  State<RenameShareForm> createState() => _RenameShareFormState();
 }
 
-*/
+class _RenameShareFormState extends State<RenameShareForm> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialName);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    Navigator.of(context).pop(_controller.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Rename Share'),
+      content: TextField(
+        controller: _controller,
+        autofocus: true,
+        textInputAction: TextInputAction.done,
+        onSubmitted: (_) => _submit(),
+        decoration: const InputDecoration(labelText: 'Share name'),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(onPressed: _submit, child: const Text('OK')),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Remove WinForms-only comment stubs and produce idiomatic, testable Flutter/Dart replacements so UI pieces can be exercised without native Win32 dependencies. 
- Make small UI surfaces usable in unit/widget tests by providing pure-Dart implementations and injectable hooks (so later wiring to `MainForm`/core can be done incrementally). 
- Reduce external dependency surface and prepare for progressive porting of larger screens by moving simple controls to Flutter-first code.

### Description
- Added `lib/ui/double_buffered_list_view.dart` which implements `DoubleBufferedListView` as an idiomatic `ListView.builder` wrapper for lazy lists. 
- Added `lib/ui/download_queue_panel.dart` which implements `DownloadQueuePanel` as a deterministic empty-state widget (temporary placeholder until transfer wiring is ported). 
- Implemented `lib/ui/html_panel.dart` providing `HTMLPanel`, `JoinCircleRequest`, and `parseDimensionJoinLink()` with an injectable `onJoinCircle` callback and a Dart-native `isMono` parity accessor. 
- Added `lib/ui/rename_share_form.dart` implementing a modal rename flow that returns the entered name via `showDialog<String>`. 
- Extended `test/ui_port_widgets_test.dart` with widget/unit tests covering link parsing, `HTMLPanel` callback firing, rename dialog submission, and `DownloadQueuePanel` rendering. 
- Updated project tracking docs: checked completed items in `TODO.md` and added porting notes/follow-ups in `agents.md` for the new ports and remaining wiring tasks.

### Testing
- Ran repository checks and local VCS validation with `git diff --check` which passed and the changes were committed. 
- Added widget/unit tests in `test/ui_port_widgets_test.dart` but `flutter test`/`flutter analyze` could not be executed because the Flutter/Dart SDK is not available in this environment (`flutter --version` and `dart --version` returned command-not-found). 
- An automated browser screenshot attempt (Playwright) against a local web server failed due to no running app (`ERR_EMPTY_RESPONSE`), which does not affect the added pure-Dart widgets but prevents visual verification here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d50fb9cc832f89e3cab0695ef291)