### PR TITLE
Port MainForm to Flutter-native controller/widget with tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,5 @@
 - `lib/model/system_log.dart` now provides a pure-Dart `SystemLog` with injectable clock/disposal/writer hooks so logging remains deterministic in tests and avoids direct filesystem coupling.
 - `lib/model/kademlia.dart` now uses an injected `KademliaBackend` interface and pure-Dart hashing/deduped lookup behavior, so announce/lookup logic can be tested with mocks before wiring real DHT transport.
 - `lib/model/peer.dart` now tracks endpoint history via pure-Dart `PeerEndpoint` value objects (with dedupe + bounded history) to preserve migration parity without networking dependencies.
+- `lib/ui/main_form.dart` now provides a Flutter-native `MainFormController`/`MainForm` with injectable flash/sound/settings dependencies and deterministic tab orchestration (`addOrSelectPanel`, `selectUser`, `privateChatReceived`, `addInternetCircle`, `setColors`) for mock-driven tests.
+- Temporary follow-up: connect `MainFormController` tab/actions to finalized routing + transfer command dispatch once `App`/`Core` orchestration is fully ported.

--- a/TODO.md
+++ b/TODO.md
@@ -167,7 +167,7 @@ This document outlines the tasks required to port the C# application to a Dart/F
   - **Public Properties**:
     - [x] `isMono`
   - **TODO**:
-    - [ ] Wire `TransfersPanel` row actions (cancel/retry/open) to finalized transfer commands once `MainForm` command routing is fully ported.
+    - [ ] Pending line-by-line parity for peer lifecycle, search fan-out, and transfer routing against the original C# flow.
 
 ## File: `./DimensionLib/Model/FileList.cs`
 
@@ -655,9 +655,9 @@ This document outlines the tasks required to port the C# application to a Dart/F
   - **Public Properties**:
     - [x] `isMono`
   - **TODO**:
-    - [ ] Wire `TransfersPanel` row actions (cancel/retry/open) to finalized transfer commands once `MainForm` command routing is fully ported.
-  - **TODO**:
     - [ ] Hook `HTMLPanel` join-circle callbacks into the final `JoinCircleForm`/`MainForm` flow once those Flutter ports are in place.
+  - **TODO**:
+    - [ ] Centralize user-facing invalid-link messaging in app-level notification/translation plumbing once available.
 
 ## File: `./Dimension/UI/SettingsForm.cs`
 
@@ -764,17 +764,18 @@ This document outlines the tasks required to port the C# application to a Dart/F
 
 ## File: `./Dimension/UI/MainForm.cs`
 
-- [ ] Port `MainForm.cs` to Dart
+- [x] Port `MainForm.cs` to Dart
   - **Classes**:
-    - [ ] `class MainForm`
+    - [x] `class MainForm`
   - **Public Methods**:
-    - [ ] `selectUser()`
-    - [ ] `privateChatReceived()`
-    - [ ] `flash()`
-    - [ ] `addOrSelectPanel()`
-    - [ ] `addInternetCircle()`
-    - [ ] `setColors()`
+    - [x] `selectUser()`
+    - [x] `privateChatReceived()`
+    - [x] `flash()`
+    - [x] `addOrSelectPanel()`
+    - [x] `addInternetCircle()`
+    - [x] `setColors()`
   - **Public Properties**:
     - [x] `isMono`
   - **TODO**:
     - [ ] Wire `TransfersPanel` row actions (cancel/retry/open) to finalized transfer commands once `MainForm` command routing is fully ported.
+    - [ ] Replace temporary in-controller tab registry with route-aware navigation state once app-wide deep linking is introduced.

--- a/test/main_form_test.dart
+++ b/test/main_form_test.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+
+import 'package:dimension/model/commands/private_chat_command.dart';
+import 'package:dimension/ui/flash_window.dart';
+import 'package:dimension/ui/join_circle_form.dart';
+import 'package:dimension/ui/main_form.dart';
+import 'package:dimension/ui/user_panel.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Settings implements MainFormSettings {
+  _Settings(this.values);
+
+  final Map<String, bool> values;
+
+  @override
+  bool getBool(String key, bool defaultValue) => values[key] ?? defaultValue;
+}
+
+class _SoundPlayer implements MainFormSoundPlayer {
+  var playCount = 0;
+
+  @override
+  Future<void> playBell() async {
+    playCount++;
+  }
+}
+
+class _FlashDriver extends FlashWindowDriver {
+  _FlashDriver({required this.activated});
+
+  bool activated;
+  var flashCount = 0;
+
+  @override
+  bool applicationIsActivated() => activated;
+
+  @override
+  bool flash({int? count, FlashType type = FlashType.all}) {
+    flashCount++;
+    return true;
+  }
+
+  @override
+  bool start({FlashType type = FlashType.all}) => true;
+
+  @override
+  bool stop() => true;
+}
+
+void main() {
+  test('addOrSelectPanel deduplicates tags and tracks selection', () {
+    final controller = MainFormController(
+      settings: _Settings({}),
+      flashDriver: _FlashDriver(activated: true),
+      soundPlayer: _SoundPlayer(),
+    );
+
+    controller.addOrSelectPanel('Welcome', Object(), (_) => const SizedBox(), 'welcome');
+    controller.addOrSelectPanel('Again', Object(), (_) => const SizedBox(), 'welcome');
+
+    expect(controller.tabs, hasLength(1));
+    expect(controller.selectedIndex, 0);
+  });
+
+  test('privateChatReceived creates user panel and appends timestamped lines', () {
+    final controller = MainFormController(
+      settings: _Settings({'Flash on Name Drop': false, 'Play sounds': false}),
+      flashDriver: _FlashDriver(activated: false),
+      soundPlayer: _SoundPlayer(),
+      clock: () => DateTime(2026, 1, 2, 3, 4),
+    );
+
+    final command = PrivateChatCommand()..content = 'hello\nthere';
+
+    controller.privateChatReceived(
+      command,
+      const MainFormPeer(id: 42, username: 'alice'),
+    );
+
+    expect(controller.tabs.single.text, 'alice');
+    final userController = controller.tabs.single.controller as UserPanelController;
+    expect(userController.lines, ['03:04 alice: hello', '03:04 alice: there']);
+  });
+
+  test('flash honors activation and user settings', () async {
+    final flashDriver = _FlashDriver(activated: false);
+    final soundPlayer = _SoundPlayer();
+    final controller = MainFormController(
+      settings: _Settings({'Flash on Name Drop': true, 'Play sounds': true}),
+      flashDriver: flashDriver,
+      soundPlayer: soundPlayer,
+    );
+
+    await controller.flash();
+
+    expect(flashDriver.flashCount, 1);
+    expect(soundPlayer.playCount, 1);
+
+    flashDriver.activated = true;
+    await controller.flash();
+    expect(flashDriver.flashCount, 1);
+    expect(soundPlayer.playCount, 1);
+  });
+
+  test('addInternetCircle deduplicates URL irrespective of case', () {
+    final controller = MainFormController(
+      settings: _Settings({}),
+      flashDriver: _FlashDriver(activated: true),
+      soundPlayer: _SoundPlayer(),
+    );
+
+    controller.addInternetCircle(
+      [InternetAddressEndpoint(InternetAddress.loopbackIPv4, 4040)],
+      'Example.com/Bootstrap.php',
+      CircleType.bootstrap,
+    );
+    controller.addInternetCircle(
+      const [],
+      'example.com/bootstrap.php',
+      CircleType.bootstrap,
+    );
+
+    expect(controller.tabs, hasLength(1));
+  });
+
+  testWidgets('MainForm renders rail destinations and selected panel', (tester) async {
+    final controller = MainFormController(
+      settings: _Settings({'Invert Colors': true}),
+      flashDriver: _FlashDriver(activated: true),
+      soundPlayer: _SoundPlayer(),
+    )..setColors();
+
+    controller.addOrSelectPanel(
+      'Welcome',
+      Object(),
+      (_) => const Center(child: Text('Welcome Body')),
+      'welcome',
+    );
+
+    await tester.pumpWidget(MaterialApp(home: MainForm(controller: controller)));
+
+    expect(find.text('Welcome'), findsOneWidget);
+    expect(find.text('Welcome Body'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
### Motivation
- Replace the legacy commented C# `MainForm` with an idiomatic Flutter/Dart implementation to advance the UI port and enable unit-testing without WinForms or platform-specific bindings. 
- Make tab/peer/chat orchestration pure-Dart and dependency-injectable so UI behavior can be tested with deterministic clocks and mockable platform adapters. 
- Track parity and remaining integration work in the repository notes so follow-ups (transfer wiring, routing) remain visible. 

### Description
- Replaced the old C# `MainForm` comment block with a Flutter-native implementation in `lib/ui/main_form.dart` that provides `MainFormController` and `MainForm` widget, including dependency-injected `MainFormSettings`, `FlashWindowDriver`, and `MainFormSoundPlayer` and a deterministic `clock` hook. 
- Implemented parity behaviors: `addOrSelectPanel`, `selectUser`, `privateChatReceived` (timestamped lines), `flash` (settings gating + flash/sound adapters), `addInternetCircle`, `setColors`, and controller-managed tab lifecycle with `SelectableTab`/`ClosableTab` support. 
- Added unit/widget tests in `test/main_form_test.dart` covering tab deduplication/selection, private-chat handling with injected clock, flash/sound gating behavior, internet-circle deduplication, and basic widget rendering. 
- Updated documentation: marked `MainForm` as ported in `TODO.md` and added a note to `AGENTS.md` describing the new `MainForm` architecture and the follow-up integration tasks. 

### Testing
- Added `test/main_form_test.dart` containing controller unit tests and a widget test; tests were not executed here because the environment lacks Flutter tooling. 
- Attempted `flutter test test/main_form_test.dart` which failed in this environment with: `bash: command not found: flutter`. 
- Attempted `dart analyze` which failed in this environment with: `bash: command not found: dart`. 
- Ran `git diff --check` which reported no whitespace or trivial diff errors (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a370d374d4832f940552c57d0cd584)