### PR TITLE
Integrate dartobjectutils for safe JSON unmarshalling

### DIFF
--- a/lib/model/fs_listing.dart
+++ b/lib/model/fs_listing.dart
@@ -1,3 +1,6 @@
+import 'package:dartobjectutils/dartobjectutils.dart';
+
+
 class FSListing {
   int id = 0;
   int parentId = 0;
@@ -31,18 +34,24 @@ class RootShare extends Folder {
 
   static RootShare fromJson(Map<String, dynamic> json) {
     return RootShare()
-      ..id = json['id'] as int? ?? 0
-      ..parentId = json['parentId'] as int? ?? 0
-      ..name = json['name'] as String? ?? ''
-      ..size = json['size'] as int? ?? 0
-      ..lastModified = json['lastModified'] as int? ?? 0
-      ..index = json['index'] as int? ?? 0
-      ..fullPath = json['fullPath'] as String? ?? ''
-      ..totalBytes = json['totalBytes'] as int? ?? 0
-      ..quickHashedBytes = json['quickHashedBytes'] as int? ?? 0
-      ..fullHashedBytes = json['fullHashedBytes'] as int? ?? 0
-      ..folderIds = List<int>.from(json['folderIds'] as Iterable? ?? const [])
-      ..fileIds = List<int>.from(json['fileIds'] as Iterable? ?? const []);
+      ..id = getNumberPropOrDefault(json, 'id', 0).toInt()
+      ..parentId = getNumberPropOrDefault(json, 'parentId', 0).toInt()
+      ..name = getStringPropOrDefault(json, 'name', '')
+      ..size = getNumberPropOrDefault(json, 'size', 0).toInt()
+      ..lastModified = getNumberPropOrDefault(json, 'lastModified', 0).toInt()
+      ..index = getNumberPropOrDefault(json, 'index', 0).toInt()
+      ..fullPath = getStringPropOrDefault(json, 'fullPath', '')
+      ..totalBytes = getNumberPropOrDefault(json, 'totalBytes', 0).toInt()
+      ..quickHashedBytes =
+          getNumberPropOrDefault(json, 'quickHashedBytes', 0).toInt()
+      ..fullHashedBytes =
+          getNumberPropOrDefault(json, 'fullHashedBytes', 0).toInt()
+      ..folderIds = getNumberArrayPropOrDefault(json, 'folderIds', <num>[])
+          .map((e) => e.toInt())
+          .toList()
+      ..fileIds = getNumberArrayPropOrDefault(json, 'fileIds', <num>[])
+          .map((e) => e.toInt())
+          .toList();
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/model/fs_listing.dart
+++ b/lib/model/fs_listing.dart
@@ -1,6 +1,5 @@
 import 'package:dartobjectutils/dartobjectutils.dart';
 
-
 class FSListing {
   int id = 0;
   int parentId = 0;

--- a/lib/ui/desktop_window_state.dart
+++ b/lib/ui/desktop_window_state.dart
@@ -21,13 +21,12 @@ class DesktopWindowGeometry {
         'offsetY': offsetY,
       };
 
-  static DesktopWindowGeometry fromJson(Map<String, Object?> json) {
-    final jsonMap = json.cast<String, dynamic>();
+  static DesktopWindowGeometry fromJson(Map<String, dynamic> json) {
     return DesktopWindowGeometry(
-      width: getNumberPropOrDefault(jsonMap, 'width', 1200).toDouble(),
-      height: getNumberPropOrDefault(jsonMap, 'height', 800).toDouble(),
-      offsetX: getNumberPropOrDefault(jsonMap, 'offsetX', 100).toDouble(),
-      offsetY: getNumberPropOrDefault(jsonMap, 'offsetY', 80).toDouble(),
+      width: getNumberPropOrDefault(json, 'width', 1200).toDouble(),
+      height: getNumberPropOrDefault(json, 'height', 800).toDouble(),
+      offsetX: getNumberPropOrDefault(json, 'offsetX', 100).toDouble(),
+      offsetY: getNumberPropOrDefault(json, 'offsetY', 80).toDouble(),
     );
   }
 }

--- a/lib/ui/desktop_window_state.dart
+++ b/lib/ui/desktop_window_state.dart
@@ -1,3 +1,4 @@
+import 'package:dartobjectutils/dartobjectutils.dart';
 import 'dart:async';
 
 class DesktopWindowGeometry {
@@ -21,11 +22,12 @@ class DesktopWindowGeometry {
       };
 
   static DesktopWindowGeometry fromJson(Map<String, Object?> json) {
+    final jsonMap = json.cast<String, dynamic>();
     return DesktopWindowGeometry(
-      width: (json['width'] as num?)?.toDouble() ?? 1200,
-      height: (json['height'] as num?)?.toDouble() ?? 800,
-      offsetX: (json['offsetX'] as num?)?.toDouble() ?? 100,
-      offsetY: (json['offsetY'] as num?)?.toDouble() ?? 80,
+      width: getNumberPropOrDefault(jsonMap, 'width', 1200).toDouble(),
+      height: getNumberPropOrDefault(jsonMap, 'height', 800).toDouble(),
+      offsetX: getNumberPropOrDefault(jsonMap, 'offsetX', 100).toDouble(),
+      offsetY: getNumberPropOrDefault(jsonMap, 'offsetY', 80).toDouble(),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.2"
+  dartobjectutils:
+    dependency: "direct main"
+    description:
+      name: dartobjectutils
+      sha256: "5bf29cf84bd57da65796f98299fc82769bd68e6b0fd8da35c75a6e7afd814345"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   fake_async:
     dependency: transitive
     description:
@@ -374,5 +382,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.4 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   crypto: ^3.0.7
   dart_udt: ^0.0.2
+  dartobjectutils: ^0.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Added `dartobjectutils` dependency to `pubspec.yaml` and refactored `lib/model/fs_listing.dart` and `lib/ui/desktop_window_state.dart` to use `getNumberPropOrDefault`, `getStringPropOrDefault`, and `getNumberArrayPropOrDefault` for robust JSON parsing. Tested that tests still pass successfully and the code remains analyze-clean.

---
*PR created automatically by Jules for task [3700566917923950432](https://jules.google.com/task/3700566917923950432) started by @arran4*