### PR TITLE
ci: install Linux dependencies for flutter build linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,7 @@ jobs:
           channel: stable
           cache: true
       - run: flutter pub get
+      - run: sudo apt-get update && sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev
       - run: flutter build linux --release
       - run: flutter build apk --release || true
 

--- a/bugreport.md
+++ b/bugreport.md
@@ -11,3 +11,11 @@ The automated test suite has 3 failing model layer tests existing on the default
    - *Issue*: Also fails to resolve the mock `File` structure during snapshot reconciliation due to incomplete index matching logic or root share ID linkages.
 
 These require codebase refactoring to properly address path traversal inside `FileList` which is outside the scope of CI migration.
+
+## Failures in `test/app_shell_test.dart`
+1. `AppShell applies web input wrappers for focus/scroll/selection`
+   - *Issue*: Fails with a layout error, likely due to a constraint mismatch in the test setup.
+2. `AppShell rebuilds for route and layout changes`
+   - *Issue*: Fails to find a Text widget with expected content.
+
+These require codebase refactoring in the test/UI layer which is outside the scope of CI migration.


### PR DESCRIPTION
Fixes the GitHub Actions CI failure where the `flutter build linux --release` step fails because it cannot find the `gtk+-3.0` package. Added a run step to `apt-get install` the necessary dependencies.

---
*PR created automatically by Jules for task [9470916015906008890](https://jules.google.com/task/9470916015906008890) started by @arran4*