### PR TITLE
ci: fix "is a directory" error on manual release creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,12 +471,18 @@ jobs:
       - run: flutter build linux --release
       - run: flutter build apk --release || true
 
+      - run: |
+          BUNDLE_DIR=$(find build/linux -type d -name "bundle" | head -n 1)
+          if [ -n "$BUNDLE_DIR" ]; then
+            tar -czf dimension-linux.tar.gz -C "$BUNDLE_DIR" .
+          fi
+
       - uses: actions/upload-artifact@v4
         with:
           name: flutter-release-bundles
           retention-days: 1
           path: |
-            build/linux/**
+            dimension-linux.tar.gz
             build/app/outputs/flutter-apk/*.apk
 
   flutter-build-web:
@@ -561,11 +567,18 @@ jobs:
 
           shopt -s globstar
 
+          files=()
+          for f in dist-release/**/*; do
+            if [[ -f "$f" ]]; then
+              files+=("$f")
+            fi
+          done
+
           if [[ -n "$prerelease" ]]; then
-            gh release create "$TAG" --generate-notes $prerelease dist-release/**/* || true
+            gh release create "$TAG" --generate-notes $prerelease "${files[@]}" || true
           else
-            gh release create "$TAG" --generate-notes $discussion_arg dist-release/**/* || \
-              gh release create "$TAG" --generate-notes dist-release/**/*
+            gh release create "$TAG" --generate-notes $discussion_arg "${files[@]}" || \
+              gh release create "$TAG" --generate-notes "${files[@]}"
           fi
 
   publish-draft:


### PR DESCRIPTION
This PR fixes the failing `manual-gh-release` CI workflow which errors out with `is a directory` when uploading artifacts using `gh release create`. The fix involves correctly packaging the built Linux bundle into a single `.tar.gz` and making sure that the script loop only feeds actual files into the Github CLI's release command.

---
*PR created automatically by Jules for task [2721796198463898183](https://jules.google.com/task/2721796198463898183) started by @arran4*